### PR TITLE
Fix status badge not showing for PR 'Needs attention'

### DIFF
--- a/src/entrypoints/sidepanel/pages/SummaryView.tsx
+++ b/src/entrypoints/sidepanel/pages/SummaryView.tsx
@@ -903,7 +903,7 @@ function splitTldrStatus(tldr: string): { body: string; statusLabel: string | nu
 
   let rest = match[1].trim();
   // Strip markdown bold/italic wrapping from label: "**Needs attention** — text" → "Needs attention — text"
-  rest = rest.replace(/^\*{1,2}(.+?)\*{1,2}(?=\s*[—–\-:]|\s*$)/, '$1').trim();
+  rest = rest.replace(/^([*_]{1,2})(.+?)\1(?=\s*[—–\-:]|\s*$)/, '$2').trim();
 
   // Try to extract a known status label from the beginning
   const lower = rest.toLowerCase();


### PR DESCRIPTION
## Summary
- Fix `splitTldrStatus` regex to accept single `\n` before `**Status:**` line (LLMs sometimes use `\n` instead of `\n\n`)
- Strip markdown bold/italic markers wrapping the status label (e.g. `**Needs attention**` → `Needs attention`) before matching against known labels

## Test plan
- [ ] Summarize an open PR with review comments — verify "Needs attention" badge appears
- [ ] Verify merged/closed PR statuses still show correct badges
- [ ] Test with LLM output that wraps label in bold markers

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)