### PR TITLE
Fix hardcoded version in Settings tab

### DIFF
--- a/src/entrypoints/sidepanel/pages/SettingsView.tsx
+++ b/src/entrypoints/sidepanel/pages/SettingsView.tsx
@@ -1285,7 +1285,7 @@ export function SettingsView({ settings, onSave, onTestLLM, onTestNotion, onFetc
         textAlign: 'center',
         lineHeight: 1.6,
       }}>
-        <div>xTil v1.0.0</div>
+        <div>xTil v{(globalThis as unknown as { chrome: typeof chrome }).chrome.runtime.getManifest().version}</div>
         <div>&copy; 2026 AI Tech Knowledge LLC</div>
         <div style={{ marginTop: '6px', display: 'flex', justifyContent: 'center', alignItems: 'center', gap: '8px', flexWrap: 'wrap', font: 'var(--md-sys-typescale-label-small)', opacity: 0.7 }}>
           <a


### PR DESCRIPTION
## Summary
- Replace hardcoded `v1.0.0` in the Settings footer with dynamic `chrome.runtime.getManifest().version`
- The extension now always displays the correct installed version

Fixes #9

## Test plan
- [ ] Build extension and load it
- [ ] Open side panel → Settings tab
- [ ] Verify the footer shows the correct version (e.g., `xTil v1.0.3`) matching `package.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)