### PR TITLE
Clear chat textarea when URL changes on active tab

### DIFF
--- a/src/entrypoints/sidepanel/App.tsx
+++ b/src/entrypoints/sidepanel/App.tsx
@@ -740,6 +740,7 @@ export function App() {
         setSummary(null);
         setNotionUrl(null);
         setChatMessages([]);
+        setInputValue('');
         setPendingResummarize(false);
       } else if (response.error === 'restricted') {
         setRestricted(true);
@@ -869,6 +870,7 @@ export function App() {
             setSummary(null);
             setChatMessages([]);
             setNotionUrl(null);
+            setInputValue('');
           }
           return;
         }
@@ -880,6 +882,7 @@ export function App() {
           setSummary(null);
           setChatMessages([]);
           setNotionUrl(null);
+          setInputValue('');
         }
         if (changeInfo.status === 'complete') extractContent();
         if (changeInfo.url) {


### PR DESCRIPTION
## Summary
- Add `setInputValue('')` alongside existing `setChatMessages([])` calls when URL changes
- Covers three code paths: restricted page navigation, in-flight summarization cancel, and fresh page extraction
- Previously the chat input retained stale text from the prior page

Fixes #15

## Test plan
- [ ] Open side panel, summarize a page, type something in the chat input
- [ ] Navigate to a different URL in the same tab
- [ ] Verify the chat input is cleared along with the summary and chat history
- [ ] Navigate to a restricted page (e.g., `chrome://extensions`) — verify input is cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)