### PR TITLE
Navigate to xtil.ai on first install

### DIFF
--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -61,9 +61,10 @@ export default defineBackground(() => {
   }
 
   // On first install, navigate to xtil.ai (reuse existing tab if open)
-  chromeObj.runtime.onInstalled.addListener((details: { reason: string }) => {
+  chromeObj.runtime.onInstalled.addListener(async (details: chrome.runtime.InstalledDetails) => {
     if (details.reason !== 'install') return;
-    chromeObj.windows.getCurrent({ populate: true }, (win: chrome.windows.Window) => {
+    try {
+      const win = await chromeObj.windows.getCurrent({ populate: true });
       const tabs = win.tabs || [];
       const existing = tabs.find((t: chrome.tabs.Tab) => {
         try { return new URL(t.url || '').hostname.endsWith('xtil.ai'); }
@@ -74,7 +75,9 @@ export default defineBackground(() => {
       } else {
         chromeObj.tabs.create({ url: 'https://xtil.ai' });
       }
-    });
+    } catch {
+      chromeObj.tabs.create({ url: 'https://xtil.ai' });
+    }
   });
 
   chromeObj.runtime.onMessage.addListener(


### PR DESCRIPTION
## Summary
- Add `chrome.runtime.onInstalled` handler in the background service worker
- Only fires on fresh installs (ignores updates/Chrome updates)
- Checks current window for an existing xtil.ai tab and activates it, or opens a new tab

Fixes #12

## Test plan
- [ ] Uninstall and reinstall the extension
- [ ] Verify xtil.ai opens in a new tab (or existing xtil.ai tab is activated)
- [ ] Verify updating the extension does NOT trigger the navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)