### PR TITLE
Show context window size setting for all providers

### DIFF
--- a/src/entrypoints/sidepanel/pages/SettingsView.tsx
+++ b/src/entrypoints/sidepanel/pages/SettingsView.tsx
@@ -855,7 +855,10 @@ export function SettingsView({ settings, onSave, onTestLLM, onTestNotion, onFetc
           name="context-window"
           type="number"
           value={currentConfig.contextWindow}
-          onInput={(e) => updateProviderConfig({ contextWindow: parseInt((e.target as HTMLInputElement).value) || 100000 })}
+          onInput={(e) => {
+            const value = parseInt((e.target as HTMLInputElement).value, 10);
+            updateProviderConfig({ contextWindow: value > 0 ? value : 100000 });
+          }}
           style={inputStyle}
         />
         <StepHint step="contextWindow" currentStep={onboardingStep} />


### PR DESCRIPTION
## Summary
- Expose the context window (tokens) input for all providers, not just self-hosted
- Users can now see and override the default context window size for any model
- The value auto-updates from the model catalog when a different model is selected
- Onboarding flow updated to not skip the context window step for standard providers

Fixes #11

## Test plan
- [ ] Open Settings with any provider (e.g., OpenAI, Anthropic)
- [ ] Verify the "Context Window (tokens)" field is visible
- [ ] Verify it shows the correct default for the selected model
- [ ] Change the model — verify the context window updates to the new model's default
- [ ] Manually edit the value — verify it persists
- [ ] Summarize a long article — verify chunking respects the edited context window

🤖 Generated with [Claude Code](https://claude.com/claude-code)