### PR TITLE
Add API key setup guidance for non-technical visitors

### DIFF
--- a/website/public/index.html
+++ b/website/public/index.html
@@ -2330,6 +2330,10 @@
       </div>
     </div>
     <p class="reveal" style="text-align:center;color:var(--text-muted);font-size:0.85rem;font-weight:300;margin-top:28px;max-width:640px;margin-left:auto;margin-right:auto;">xTil automatically discovers available models from your provider and probes each model's actual vision capability &mdash; so image analysis just works without manual configuration. Also supports xAI (Grok) and DeepSeek.</p>
+    <p class="reveal" style="text-align:center;font-size:0.85rem;margin-top:16px;max-width:640px;margin-left:auto;margin-right:auto;">
+      <span style="color:var(--text-muted);font-weight:300;">Already use ChatGPT or Claude? You likely have an API key.</span>
+      <span style="color:var(--primary-bright);font-weight:400;"> Most summaries cost less than $0.01.</span>
+    </p>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- Add reassuring one-liner below the BYOK providers section
- "Already use ChatGPT or Claude? You likely have an API key. Most summaries cost less than $0.01."
- Reduces friction for non-developer visitors intimidated by "API key" terminology
- Sets cost expectations upfront

Fixes #21

## Test plan
- [ ] Verify the text appears below the providers grid
- [ ] Check styling on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)