### PR TITLE
Add competitor comparison table to landing page

### DIFF
--- a/website/public/index.html
+++ b/website/public/index.html
@@ -1327,6 +1327,7 @@
     }
 
     /* ─── Comparison table ─── */
+    .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border-width: 0; }
     .compare-section { padding: 80px 0; }
     .compare-table { width: 100%; border-collapse: collapse; font-size: 0.85rem; margin-top: 32px; }
     .compare-table th, .compare-table td { padding: 12px 16px; text-align: left; border-bottom: 1px solid var(--border); }
@@ -2415,11 +2416,11 @@
       <table class="compare-table">
         <thead>
           <tr>
-            <th></th>
-            <th class="xtil-col">xTil</th>
-            <th>Glasp</th>
-            <th>Generic summarizers</th>
-            <th>Paid tools</th>
+            <th scope="col"><span class="sr-only">Feature</span></th>
+            <th scope="col" class="xtil-col">xTil</th>
+            <th scope="col">Glasp</th>
+            <th scope="col">Generic summarizers</th>
+            <th scope="col">Paid tools</th>
           </tr>
         </thead>
         <tbody>


### PR DESCRIPTION
## Summary
- Add "Why xTil?" section with a comparison table
- Compares xTil vs Glasp, generic summarizers, and paid tools
- 7 feature rows: privacy (BYOK), multi-provider, platform-aware extraction, diagrams, chat, open source, Notion export
- Responsive with horizontal scroll on mobile, smaller font on narrow viewports
- Placed between privacy section and final CTA

Fixes #25

## Test plan
- [ ] Verify table renders correctly on desktop
- [ ] Verify horizontal scroll works on mobile
- [ ] Check color coding: green checks, yellow "Partial", muted dashes
- [ ] Verify xTil column is highlighted with accent color

🤖 Generated with [Claude Code](https://claude.com/claude-code)