### PR TITLE
Add feature panel hover effects and prefers-reduced-motion

### DIFF
--- a/website/public/index.html
+++ b/website/public/index.html
@@ -1342,20 +1342,29 @@
 
     /* ─── Feature panel hover ─── */
     .mock-panel-card {
-      transition: border-color 0.3s, box-shadow 0.3s;
+      transition: box-shadow 0.3s;
     }
     .mock-panel-card:hover {
-      border-color: rgba(109, 95, 245, 0.25);
-      box-shadow: 0 4px 32px rgba(109, 95, 245, 0.1);
+      box-shadow: 0 4px 32px rgba(109, 95, 245, 0.1), 0 0 0 1px rgba(109, 95, 245, 0.25);
     }
 
     /* ─── Reduced motion ─── */
     @media (prefers-reduced-motion: reduce) {
+      html { scroll-behavior: auto; }
       .reveal { transition: none; opacity: 1; transform: none; }
-      .ticker-track { animation: none; }
-      .bento-card { transition: none; }
-      .mock-panel-card { transition: none; }
-      .pipeline-step:hover .step-orb { transition: none; }
+      .ticker-track, .orb, .hero h1 .gradient, .mock-article .hl,
+      .browser-mockup.visible .mock-badges, .browser-mockup.visible .mock-thumb,
+      .browser-mockup.visible .mock-ptitle, .browser-mockup.visible .mock-pmeta,
+      .browser-mockup.visible .mock-sec, .browser-mockup.visible .mock-diagram .dg-node,
+      .browser-mockup.visible .mock-diagram .dg-arrow, .browser-mockup.visible .mock-chat-msg,
+      .browser-mockup.visible .mock-chat-input {
+        animation: none;
+      }
+      a, nav, .btn-primary, .btn-ghost, .provider-card, .bento-card,
+      .mock-panel-card, .pipeline-step:hover .step-orb {
+        transition: none;
+      }
+      .nav-cta { transition: none !important; }
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- Add subtle purple glow + border highlight on feature panel mockup hover
- Add `prefers-reduced-motion: reduce` media query that disables all animations: scroll reveal fade-ins, ticker scroll, card hover transitions, and step orb transitions
- The page already had scroll-reveal animations via IntersectionObserver — this PR adds the missing accessibility escape hatch

Closes #26

## Test plan
- [ ] Hover over feature mockup panels — should show subtle purple glow
- [ ] Enable "Reduce motion" in OS accessibility settings — all animations should be disabled
- [ ] Verify ticker still displays (just doesn't scroll) with reduced motion

🤖 Generated with [Claude Code](https://claude.com/claude-code)