### PR TITLE
fix(messaging): make 120s sendMessage timeout idle-based, not total

### DIFF
--- a/src/entrypoints/sidepanel/App.tsx
+++ b/src/entrypoints/sidepanel/App.tsx
@@ -275,7 +275,7 @@ async function runMermaidFixAttempt(
     summary: annotatedSummary,
     content,
     theme,
-  }) as ChatResponseMessage;
+  }, { keepAliveTypes: ['CHAT_CHUNK'] }) as ChatResponseMessage;
 
   // Update debug panel with the actual conversation from this fix attempt
   if (fixResponse.conversationLog?.length && setConversationLog) {
@@ -1307,7 +1307,7 @@ export function App() {
         content: extractedContent,
         userInstructions,
         tabId: originTabId ?? undefined,
-      }) as SummaryResultMessage;
+      }, { keepAliveTypes: ['SUMMARY_CHUNK', 'GENRE_CLASSIFIED'] }) as SummaryResultMessage;
 
       // Store raw LLM responses and system prompt for debug panel BEFORE
       // checking success — they're available even when summarization fails
@@ -1729,7 +1729,7 @@ export function App() {
         content,
         tabId: originTabId ?? undefined,
         webSearch: opts?.webSearch || undefined,
-      }) as ChatResponseMessage;
+      }, { keepAliveTypes: ['CHAT_CHUNK'] }) as ChatResponseMessage;
 
       if (!response.success || !response.message) {
         throw new Error(response.error || 'Chat failed');

--- a/src/lib/messaging/bridge.ts
+++ b/src/lib/messaging/bridge.ts
@@ -3,23 +3,59 @@ import type { Message } from './types';
 const chromeRuntime = (globalThis as unknown as { chrome: { runtime: typeof chrome.runtime } }).chrome.runtime;
 const chromeTabs = (globalThis as unknown as { chrome: { tabs: typeof chrome.tabs } }).chrome.tabs;
 
-const MESSAGE_TIMEOUT_MS = 120_000; // 2 minutes
+// 120s is an inactivity (idle) timeout — see SendMessageOptions.keepAliveTypes.
+const MESSAGE_TIMEOUT_MS = 120_000;
 
-export function sendMessage<T extends Message>(message: T): Promise<Message> {
+export interface SendMessageOptions {
+  /**
+   * Broadcast message types whose arrival counts as "the request is still
+   * making progress" — receiving one resets the inactivity timer. Use this
+   * for streaming flows (SUMMARIZE → SUMMARY_CHUNK, CHAT_MESSAGE → CHAT_CHUNK)
+   * so a long generation doesn't trip the timeout while chunks are arriving.
+   */
+  keepAliveTypes?: readonly string[];
+}
+
+export function sendMessage<T extends Message>(
+  message: T,
+  options?: SendMessageOptions,
+): Promise<Message> {
   return new Promise((resolve, reject) => {
     let settled = false;
+    let timer: ReturnType<typeof setTimeout>;
 
-    const timer = setTimeout(() => {
-      if (!settled) {
-        settled = true;
-        reject(new Error(`Message "${message.type}" timed out after ${MESSAGE_TIMEOUT_MS / 1000}s`));
-      }
-    }, MESSAGE_TIMEOUT_MS);
+    const onTimeout = () => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(new Error(`Message "${message.type}" timed out after ${MESSAGE_TIMEOUT_MS / 1000}s with no activity`));
+    };
+    const armTimer = () => { timer = setTimeout(onTimeout, MESSAGE_TIMEOUT_MS); };
+
+    const keepAliveTypes = options?.keepAliveTypes;
+    const activityListener = keepAliveTypes && keepAliveTypes.length > 0
+      ? (msg: unknown) => {
+          if (settled) return;
+          const t = (msg as { type?: unknown } | undefined)?.type;
+          if (typeof t === 'string' && keepAliveTypes.includes(t)) {
+            clearTimeout(timer);
+            armTimer();
+          }
+        }
+      : null;
+
+    const cleanup = () => {
+      clearTimeout(timer);
+      if (activityListener) chromeRuntime.onMessage.removeListener(activityListener);
+    };
+
+    if (activityListener) chromeRuntime.onMessage.addListener(activityListener);
+    armTimer();
 
     chromeRuntime.sendMessage(message, (response: unknown) => {
       if (settled) return;
       settled = true;
-      clearTimeout(timer);
+      cleanup();
       if (chromeRuntime.lastError) {
         reject(new Error(chromeRuntime.lastError.message));
       } else {

--- a/src/lib/messaging/bridge.ts
+++ b/src/lib/messaging/bridge.ts
@@ -12,6 +12,12 @@ export interface SendMessageOptions {
    * making progress" — receiving one resets the inactivity timer. Use this
    * for streaming flows (SUMMARIZE → SUMMARY_CHUNK, CHAT_MESSAGE → CHAT_CHUNK)
    * so a long generation doesn't trip the timeout while chunks are arriving.
+   *
+   * The listener is scoped to the request's `tabId` when both the outgoing
+   * message and the incoming broadcast carry one — this prevents a chunk
+   * stream for one tab from keeping a stuck request in another tab alive.
+   * If either side omits `tabId`, the listener falls back to runtime-wide
+   * matching (acceptable for single-side-panel usage).
    */
   keepAliveTypes?: readonly string[];
 }
@@ -33,14 +39,20 @@ export function sendMessage<T extends Message>(
     const armTimer = () => { timer = setTimeout(onTimeout, MESSAGE_TIMEOUT_MS); };
 
     const keepAliveTypes = options?.keepAliveTypes;
+    const requestTabId = (message as { tabId?: unknown }).tabId;
     const activityListener = keepAliveTypes && keepAliveTypes.length > 0
       ? (msg: unknown) => {
           if (settled) return;
-          const t = (msg as { type?: unknown } | undefined)?.type;
-          if (typeof t === 'string' && keepAliveTypes.includes(t)) {
-            clearTimeout(timer);
-            armTimer();
+          const incoming = msg as { type?: unknown; tabId?: unknown } | undefined;
+          const t = incoming?.type;
+          if (typeof t !== 'string' || !keepAliveTypes.includes(t)) return;
+          // Scope by tabId when both sides have one — prevents one tab's
+          // chunks from keeping a stuck request in another tab alive.
+          if (requestTabId !== undefined && incoming?.tabId !== undefined && incoming.tabId !== requestTabId) {
+            return;
           }
+          clearTimeout(timer);
+          armTimer();
         }
       : null;
 


### PR DESCRIPTION
## Summary
- The `chrome.runtime.sendMessage` wrapper in `src/lib/messaging/bridge.ts` enforced a hard 120 s deadline on the whole request/response cycle. For long-running generations (`SUMMARIZE`, `CHAT_MESSAGE`) this surfaced as a "timed out" error even though `SUMMARY_CHUNK` / `CHAT_CHUNK` / `GENRE_CLASSIFIED` broadcasts were arriving steadily.
- `sendMessage` now accepts `{ keepAliveTypes: string[] }`. When set, an incoming broadcast of any listed type resets the 120 s timer. Effective semantics:
  - 120 s deadline for the **first** chunk
  - 120 s deadline **between** any two consecutive chunks (catches a stuck stream)
  - **unbounded** total runtime as long as chunks keep arriving
- Short request/response messages (`EXTRACT_CONTENT`, `EXPORT`, etc.) keep the original total-timeout semantics by simply not passing the option.

The three streaming call sites in `App.tsx` pass the appropriate types:
- `SUMMARIZE` → `['SUMMARY_CHUNK', 'GENRE_CLASSIFIED']`
- `CHAT_MESSAGE` (both call sites) → `['CHAT_CHUNK']`

## Test plan
- [ ] Reload the extension from `.output/chrome-mv3/`
- [ ] Run a long summarization (large article + a slow model) — verify it completes without a 120 s timeout error as long as chunks keep streaming
- [ ] Stop the network mid-stream — verify the timeout fires after 120 s of inactivity
- [ ] Run a chat refinement — same expectation
- [ ] Confirm short messages (extract, export) still time out at 120 s if the background hangs

🤖 Generated with [Claude Code](https://claude.com/claude-code)