### PR TITLE
feat(llm): gracefully handle discontinued provider models

### DIFF
--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -219,6 +219,10 @@ async function handleMessage(message: Message): Promise<Message> {
       return handleGetSettings();
     case 'SAVE_SETTINGS':
       return handleSaveSettings(message.settings);
+    case 'CLEAR_MIGRATION_NOTICES':
+      return handleClearMigrationNotices(
+        (message as import('@/lib/messaging/types').ClearMigrationNoticesMessage).timestamps,
+      );
     case 'FETCH_NOTION_DATABASES':
       return handleFetchNotionDatabases();
     case 'FETCH_MODELS':
@@ -763,17 +767,7 @@ async function handleSummarize(content: ExtractedContent, userInstructions?: str
     // If the model was retired, persist the swap before bubbling the error so
     // the next attempt uses the new model automatically. The user-facing
     // message tells them we've already switched.
-    let surfaced = err instanceof Error ? err.message : String(err);
-    try {
-      const settings = await getSettings();
-      const llmConfig = getActiveProviderConfig(settings);
-      const result = await handleDiscontinuationOnError(err, llmConfig);
-      if (result) {
-        const newName = result.notice.toName || result.notice.to;
-        const provName = result.notice.providerName || result.notice.providerId;
-        surfaced = `${provName} retired ${result.notice.from}. Switched to ${newName} — please try again.`;
-      }
-    } catch { /* deprecation handler is best-effort */ }
+    const surfaced = await surfaceDiscontinuationError(err, getActiveProviderConfig(await getSettings()));
     return {
       type: 'SUMMARY_RESULT',
       success: false,
@@ -991,17 +985,7 @@ ${chatFormatInstructions}${imageCapabilityNote}`;
 
     return { type: 'CHAT_RESPONSE', success: true, message: response, rawResponses, conversationLog, lastRequestBody: lastRequestBody || undefined, lastResponseBody: lastResponseBody || undefined };
   } catch (err) {
-    let surfaced = err instanceof Error ? err.message : String(err);
-    try {
-      const settings = await getSettings();
-      const llmConfig = getActiveProviderConfig(settings);
-      const result = await handleDiscontinuationOnError(err, llmConfig);
-      if (result) {
-        const newName = result.notice.toName || result.notice.to;
-        const provName = result.notice.providerName || result.notice.providerId;
-        surfaced = `${provName} retired ${result.notice.from}. Switched to ${newName} — please try again.`;
-      }
-    } catch { /* deprecation handler is best-effort */ }
+    const surfaced = await surfaceDiscontinuationError(err, getActiveProviderConfig(await getSettings()));
     return {
       type: 'CHAT_RESPONSE',
       success: false,
@@ -1117,41 +1101,46 @@ async function handleTestLLMConnection(): Promise<ConnectionTestResultMessage> {
 }
 
 async function handleProbeVision(msg: import('@/lib/messaging/types').ProbeVisionMessage): Promise<Message> {
+  const settings = await getSettings();
+  // Use provided config (from unsaved UI state) or fall back to saved settings
+  const llmConfig = msg.providerId && msg.model ? {
+    providerId: msg.providerId,
+    apiKey: msg.apiKey || '',
+    model: msg.model,
+    endpoint: msg.endpoint,
+    contextWindow: 100000,
+  } : getActiveProviderConfig(settings);
+  if (!llmConfig.apiKey && llmConfig.providerId !== 'self-hosted') {
+    return { type: 'PROBE_VISION_RESULT', success: false, error: 'No API key' } as Message;
+  }
   try {
-    const settings = await getSettings();
-    // Use provided config (from unsaved UI state) or fall back to saved settings
-    const llmConfig = msg.providerId && msg.model ? {
-      providerId: msg.providerId,
-      apiKey: msg.apiKey || '',
-      model: msg.model,
-      endpoint: msg.endpoint,
-      contextWindow: 100000,
-    } : getActiveProviderConfig(settings);
-    if (!llmConfig.apiKey && llmConfig.providerId !== 'self-hosted') {
-      return { type: 'PROBE_VISION_RESULT', success: false, error: 'No API key' } as Message;
-    }
     const provider = createProvider(llmConfig);
     const vision = await getModelVision(provider, llmConfig.providerId, llmConfig.model);
     return { type: 'PROBE_VISION_RESULT', success: true, vision } as Message;
   } catch (err) {
-    let surfaced = err instanceof Error ? err.message : String(err);
-    try {
-      const cfg = msg.providerId && msg.model ? {
-        providerId: msg.providerId,
-        apiKey: msg.apiKey || '',
-        model: msg.model,
-        endpoint: msg.endpoint,
-        contextWindow: 100000,
-      } : getActiveProviderConfig(await getSettings());
-      const result = await handleDiscontinuationOnError(err, cfg);
-      if (result) {
-        const newName = result.notice.toName || result.notice.to;
-        const provName = result.notice.providerName || result.notice.providerId;
-        surfaced = `${provName} retired ${result.notice.from}. Switched to ${newName} — please try again.`;
-      }
-    } catch { /* best-effort */ }
+    const surfaced = await surfaceDiscontinuationError(err, llmConfig);
     return { type: 'PROBE_VISION_RESULT', success: false, error: surfaced } as Message;
   }
+}
+
+/**
+ * If `err` indicates the configured model has been discontinued, persist the
+ * swap (handleDiscontinuationOnError) and return the friendly user-facing
+ * message. Otherwise return the original error message verbatim.
+ */
+async function surfaceDiscontinuationError(
+  err: unknown,
+  llmConfig: import('@/lib/llm/types').ProviderConfig,
+): Promise<string> {
+  try {
+    const result = await handleDiscontinuationOnError(err, llmConfig);
+    if (result) {
+      const newName = result.notice.toName || result.notice.to;
+      const provName = result.notice.providerName || result.notice.providerId;
+      return `${provName} retired ${result.notice.from}. Switched to ${newName} — please try again.`;
+    }
+  } catch { /* best-effort — fall through to raw error */ }
+  return err instanceof Error ? err.message : String(err);
 }
 
 /**
@@ -1169,15 +1158,14 @@ async function runWithDiscontinuationHandling<T>(
   try {
     return await fn(llmConfig);
   } catch (err) {
-    const result = await handleDiscontinuationOnError(err, llmConfig);
-    if (!result) throw err;
     if (opts?.retry) {
+      const result = await handleDiscontinuationOnError(err, llmConfig);
+      if (!result) throw err;
       return await fn(result.newConfig);
     }
-    const newName = result.notice.toName || result.notice.to;
-    throw new Error(
-      `${result.notice.providerId === 'xai' ? 'xAI' : (result.notice.providerName || result.notice.providerId)} retired ${result.notice.from}. Switched to ${newName} — please try again.`,
-    );
+    const surfaced = await surfaceDiscontinuationError(err, llmConfig);
+    if (surfaced === (err instanceof Error ? err.message : String(err))) throw err;
+    throw new Error(surfaced);
   }
 }
 
@@ -1257,6 +1245,28 @@ async function handleSaveSettings(partial: object): Promise<SaveSettingsResultMe
     return { type: 'SAVE_SETTINGS_RESULT', success: true };
   } catch {
     return { type: 'SAVE_SETTINGS_RESULT', success: false };
+  }
+}
+
+/**
+ * Remove migration notices the side panel has displayed. Reads the latest
+ * pendingMigrationNotices through the storage write queue and filters out
+ * only the entries whose `at` timestamps the side panel reported, so notices
+ * added concurrently by the background script aren't lost.
+ */
+async function handleClearMigrationNotices(
+  timestamps: number[],
+): Promise<import('@/lib/messaging/types').ClearMigrationNoticesResultMessage> {
+  try {
+    const seen = new Set(timestamps);
+    await saveSettings((current) => ({
+      pendingMigrationNotices: (current.pendingMigrationNotices ?? []).filter(
+        (n) => !seen.has(n.at),
+      ),
+    }));
+    return { type: 'CLEAR_MIGRATION_NOTICES_RESULT', success: true };
+  } catch {
+    return { type: 'CLEAR_MIGRATION_NOTICES_RESULT', success: false };
   }
 }
 

--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -2,6 +2,7 @@ import { getSettings, saveSettings } from '@/lib/storage/settings';
 import { getActiveProviderConfig } from '@/lib/storage/types';
 import { createProvider, getProviderDefinition } from '@/lib/llm/registry';
 import { fetchModels, getCatalogEntry } from '@/lib/llm/models';
+import { handleDiscontinuationOnError } from '@/lib/llm/deprecation';
 import { summarize, ImageRequestError } from '@/lib/summarizer/summarizer';
 import { getSystemPrompt } from '@/lib/summarizer/prompts';
 import { fetchImages } from '@/lib/images/fetcher';
@@ -759,10 +760,24 @@ async function handleSummarize(content: ExtractedContent, userInstructions?: str
       throw err;
     }
   } catch (err) {
+    // If the model was retired, persist the swap before bubbling the error so
+    // the next attempt uses the new model automatically. The user-facing
+    // message tells them we've already switched.
+    let surfaced = err instanceof Error ? err.message : String(err);
+    try {
+      const settings = await getSettings();
+      const llmConfig = getActiveProviderConfig(settings);
+      const result = await handleDiscontinuationOnError(err, llmConfig);
+      if (result) {
+        const newName = result.notice.toName || result.notice.to;
+        const provName = result.notice.providerName || result.notice.providerId;
+        surfaced = `${provName} retired ${result.notice.from}. Switched to ${newName} — please try again.`;
+      }
+    } catch { /* deprecation handler is best-effort */ }
     return {
       type: 'SUMMARY_RESULT',
       success: false,
-      error: err instanceof Error ? err.message : String(err),
+      error: surfaced,
       rawResponses,
       systemPrompt: actualSystemPrompt,
       conversationLog: lastConversation.length > 0 ? lastConversation : undefined,
@@ -976,10 +991,21 @@ ${chatFormatInstructions}${imageCapabilityNote}`;
 
     return { type: 'CHAT_RESPONSE', success: true, message: response, rawResponses, conversationLog, lastRequestBody: lastRequestBody || undefined, lastResponseBody: lastResponseBody || undefined };
   } catch (err) {
+    let surfaced = err instanceof Error ? err.message : String(err);
+    try {
+      const settings = await getSettings();
+      const llmConfig = getActiveProviderConfig(settings);
+      const result = await handleDiscontinuationOnError(err, llmConfig);
+      if (result) {
+        const newName = result.notice.toName || result.notice.to;
+        const provName = result.notice.providerName || result.notice.providerId;
+        surfaced = `${provName} retired ${result.notice.from}. Switched to ${newName} — please try again.`;
+      }
+    } catch { /* deprecation handler is best-effort */ }
     return {
       type: 'CHAT_RESPONSE',
       success: false,
-      error: err instanceof Error ? err.message : String(err),
+      error: surfaced,
     };
   } finally {
     if (tabId != null) activeChats.delete(tabId);
@@ -1058,17 +1084,24 @@ async function handleTestLLMConnection(): Promise<ConnectionTestResultMessage> {
   try {
     const settings = await getSettings();
     const llmConfig = getActiveProviderConfig(settings);
-    const provider = createProvider(llmConfig);
     // Call sendChat directly instead of testConnection() so errors propagate.
     // If sendChat doesn't throw, the connection works (even if response is empty
     // due to e.g. Gemini safety filters on trivial prompts).
-    await provider.sendChat(
-      [{ role: 'user', content: 'Reply with "ok"' }],
-      { maxTokens: 10 },
+    const { provider: workingProvider, config: workingConfig } = await runWithDiscontinuationHandling(
+      llmConfig,
+      async (cfg) => {
+        const p = createProvider(cfg);
+        await p.sendChat(
+          [{ role: 'user', content: 'Reply with "ok"' }],
+          { maxTokens: 10 },
+        );
+        return { provider: p, config: cfg };
+      },
+      { retry: true },
     );
 
     // Probe vision capabilities
-    const vision = await getModelVision(provider, llmConfig.providerId, llmConfig.model);
+    const vision = await getModelVision(workingProvider, workingConfig.providerId, workingConfig.model);
 
     return { type: 'CONNECTION_TEST_RESULT', success: true, visionSupport: vision };
   } catch (err) {
@@ -1101,7 +1134,50 @@ async function handleProbeVision(msg: import('@/lib/messaging/types').ProbeVisio
     const vision = await getModelVision(provider, llmConfig.providerId, llmConfig.model);
     return { type: 'PROBE_VISION_RESULT', success: true, vision } as Message;
   } catch (err) {
-    return { type: 'PROBE_VISION_RESULT', success: false, error: err instanceof Error ? err.message : String(err) } as Message;
+    let surfaced = err instanceof Error ? err.message : String(err);
+    try {
+      const cfg = msg.providerId && msg.model ? {
+        providerId: msg.providerId,
+        apiKey: msg.apiKey || '',
+        model: msg.model,
+        endpoint: msg.endpoint,
+        contextWindow: 100000,
+      } : getActiveProviderConfig(await getSettings());
+      const result = await handleDiscontinuationOnError(err, cfg);
+      if (result) {
+        const newName = result.notice.toName || result.notice.to;
+        const provName = result.notice.providerName || result.notice.providerId;
+        surfaced = `${provName} retired ${result.notice.from}. Switched to ${newName} — please try again.`;
+      }
+    } catch { /* best-effort */ }
+    return { type: 'PROBE_VISION_RESULT', success: false, error: surfaced } as Message;
+  }
+}
+
+/**
+ * Run an LLM-using callback. If the underlying call fails because the model is
+ * gone from the provider's /models list, persist a swap to a capability-matched
+ * fallback (`handleDiscontinuationOnError`), then either retry once (if the
+ * caller opted in) or rethrow with a friendly message that tells the user we've
+ * already updated their settings.
+ */
+async function runWithDiscontinuationHandling<T>(
+  llmConfig: import('@/lib/llm/types').ProviderConfig,
+  fn: (config: import('@/lib/llm/types').ProviderConfig) => Promise<T>,
+  opts?: { retry?: boolean },
+): Promise<T> {
+  try {
+    return await fn(llmConfig);
+  } catch (err) {
+    const result = await handleDiscontinuationOnError(err, llmConfig);
+    if (!result) throw err;
+    if (opts?.retry) {
+      return await fn(result.newConfig);
+    }
+    const newName = result.notice.toName || result.notice.to;
+    throw new Error(
+      `${result.notice.providerId === 'xai' ? 'xAI' : (result.notice.providerName || result.notice.providerId)} retired ${result.notice.from}. Switched to ${newName} — please try again.`,
+    );
   }
 }
 

--- a/src/entrypoints/sidepanel/App.tsx
+++ b/src/entrypoints/sidepanel/App.tsx
@@ -932,6 +932,25 @@ export function App() {
     });
   }, [setThemeMode]);
 
+  // Keep React state in sync when the background mutates settings on its own —
+  // notably the model auto-swap on a discontinuation. Without this, a stale
+  // SettingsView debounced-save would clobber the swap on the next user edit.
+  useEffect(() => {
+    const chromeStorage = (globalThis as unknown as { chrome: { storage: typeof chrome.storage } }).chrome.storage;
+    const handler = (
+      changes: { [key: string]: chrome.storage.StorageChange },
+      area: chrome.storage.AreaName,
+    ) => {
+      if (area !== 'local') return;
+      const change = changes['xtil_settings'];
+      if (!change) return;
+      const next = change.newValue as Settings | undefined;
+      if (next) setSettings(next);
+    };
+    chromeStorage.onChanged.addListener(handler);
+    return () => chromeStorage.onChanged.removeListener(handler);
+  }, []);
+
   // Show any pending model-migration notices (e.g. an LLM model was discontinued
   // by the provider and the runtime auto-swapped to a fallback) and clear them.
   // We surface all accumulated notices, not just the latest, and remove them

--- a/src/entrypoints/sidepanel/App.tsx
+++ b/src/entrypoints/sidepanel/App.tsx
@@ -932,20 +932,30 @@ export function App() {
     });
   }, [setThemeMode]);
 
-  // Show any pending model-migration notice (e.g. an LLM model was discontinued
-  // by the provider and the runtime auto-swapped to a fallback) and clear it.
+  // Show any pending model-migration notices (e.g. an LLM model was discontinued
+  // by the provider and the runtime auto-swapped to a fallback) and clear them.
+  // We surface all accumulated notices, not just the latest, and remove them
+  // from storage by `at` timestamp so concurrently-added notices aren't lost.
   useEffect(() => {
     const notices = settings.pendingMigrationNotices;
     if (!notices?.length) return;
-    const newest = notices[notices.length - 1];
-    const provName = newest.providerName || newest.providerId;
-    const toName = newest.toName || newest.to;
-    setToast({
-      message: `${provName} retired ${newest.from}. Switched to ${toName}.`,
-      type: 'info',
-    });
-    sendMessage({ type: 'SAVE_SETTINGS', settings: { pendingMigrationNotices: [] } }).catch(() => {});
-    setSettings((s) => ({ ...s, pendingMigrationNotices: [] }));
+    const describe = (n: typeof notices[number]) => {
+      const provName = n.providerName || n.providerId;
+      const toName = n.toName || n.to;
+      return `${provName} retired ${n.from} → ${toName}`;
+    };
+    const message = notices.length === 1
+      ? `${describe(notices[0])}.`
+      : `Migrated ${notices.length} retired models: ${notices.map(describe).join('; ')}.`;
+    setToast({ message, type: 'info' });
+    const timestamps = notices.map((n) => n.at);
+    sendMessage({ type: 'CLEAR_MIGRATION_NOTICES', timestamps }).catch(() => {});
+    setSettings((s) => ({
+      ...s,
+      pendingMigrationNotices: (s.pendingMigrationNotices ?? []).filter(
+        (n) => !timestamps.includes(n.at),
+      ),
+    }));
   }, [settings.pendingMigrationNotices]);
 
   // Auto-extract on mount

--- a/src/entrypoints/sidepanel/App.tsx
+++ b/src/entrypoints/sidepanel/App.tsx
@@ -932,6 +932,22 @@ export function App() {
     });
   }, [setThemeMode]);
 
+  // Show any pending model-migration notice (e.g. an LLM model was discontinued
+  // by the provider and the runtime auto-swapped to a fallback) and clear it.
+  useEffect(() => {
+    const notices = settings.pendingMigrationNotices;
+    if (!notices?.length) return;
+    const newest = notices[notices.length - 1];
+    const provName = newest.providerName || newest.providerId;
+    const toName = newest.toName || newest.to;
+    setToast({
+      message: `${provName} retired ${newest.from}. Switched to ${toName}.`,
+      type: 'info',
+    });
+    sendMessage({ type: 'SAVE_SETTINGS', settings: { pendingMigrationNotices: [] } }).catch(() => {});
+    setSettings((s) => ({ ...s, pendingMigrationNotices: [] }));
+  }, [settings.pendingMigrationNotices]);
+
   // Auto-extract on mount
   useEffect(() => {
     extractContent();

--- a/src/entrypoints/sidepanel/pages/SettingsView.tsx
+++ b/src/entrypoints/sidepanel/pages/SettingsView.tsx
@@ -130,13 +130,16 @@ export function SettingsView({ settings, onSave, onTestLLM, onTestNotion, onFetc
     const result: Record<string, ModelInfo[]> = {};
     for (const def of PROVIDER_DEFINITIONS) {
       const pid = def.id;
-      let models = getCatalogModels(pid);
+      // Models the runtime confirmed are gone from the provider's /models list.
+      // Hide them from the picker even if they're still in the bundled catalog.
+      const discontinued = new Set(settings.discoveredDiscontinued?.[pid] ?? []);
+      let models = getCatalogModels(pid).filter((m) => !discontinued.has(m.id));
 
       // Append cached API extras (genuinely new models from previous fetches)
       if (settings.cachedModels?.[pid]) {
         const catalogIds = getCatalogModelIds(pid);
         const extras = settings.cachedModels[pid].filter(
-          (m) => !catalogIds.has(m.id) && !isModelExcluded(pid, m.id),
+          (m) => !catalogIds.has(m.id) && !isModelExcluded(pid, m.id) && !discontinued.has(m.id),
         );
         models = [...models, ...extras];
       }

--- a/src/lib/llm/deprecation.ts
+++ b/src/lib/llm/deprecation.ts
@@ -96,17 +96,6 @@ export async function handleDiscontinuationOnError(
   const fallback = pickFallbackModel(liveModels, ctx);
   if (!fallback) return null;
 
-  const settings = await getSettings();
-  const existing = settings.providerConfigs[config.providerId] || config;
-  const newConfig: ProviderConfig = {
-    ...existing,
-    model: fallback.id,
-    contextWindow: fallback.contextWindow || existing.contextWindow,
-  };
-
-  const discoveredFor = new Set(settings.discoveredDiscontinued?.[config.providerId] ?? []);
-  discoveredFor.add(config.model);
-
   const notice: MigrationNotice = {
     providerId: config.providerId,
     from: config.model,
@@ -116,16 +105,31 @@ export async function handleDiscontinuationOnError(
     at: Date.now(),
   };
 
-  await saveSettings({
-    providerConfigs: {
-      ...settings.providerConfigs,
-      [config.providerId]: newConfig,
-    },
-    discoveredDiscontinued: {
-      ...settings.discoveredDiscontinued,
-      [config.providerId]: [...discoveredFor],
-    },
-    pendingMigrationNotices: [...(settings.pendingMigrationNotices ?? []), notice],
+  // Use the function form of saveSettings so the merge runs against the freshest
+  // snapshot under the storage write queue — concurrent failures (e.g. summary +
+  // vision probe failing on the same retired model) won't lose each other's
+  // notices or discoveredDiscontinued entries.
+  let newConfig!: ProviderConfig;
+  await saveSettings((current) => {
+    const existing = current.providerConfigs[config.providerId] || config;
+    newConfig = {
+      ...existing,
+      model: fallback.id,
+      contextWindow: fallback.contextWindow || existing.contextWindow,
+    };
+    const discoveredFor = new Set(current.discoveredDiscontinued?.[config.providerId] ?? []);
+    discoveredFor.add(config.model);
+    return {
+      providerConfigs: {
+        ...current.providerConfigs,
+        [config.providerId]: newConfig,
+      },
+      discoveredDiscontinued: {
+        ...current.discoveredDiscontinued,
+        [config.providerId]: [...discoveredFor],
+      },
+      pendingMigrationNotices: [...(current.pendingMigrationNotices ?? []), notice],
+    };
   });
 
   return { newConfig, notice };

--- a/src/lib/llm/deprecation.ts
+++ b/src/lib/llm/deprecation.ts
@@ -1,0 +1,137 @@
+import type { ModelInfo, ProviderConfig } from './types';
+import type { MigrationNotice, Settings } from '../storage/types';
+import { fetchModels, getCatalogEntry } from './models';
+import { getProviderDefinition } from './registry';
+import { getSettings, saveSettings } from '../storage/settings';
+
+const MODEL_ERROR_PATTERNS = [
+  /\bmodel[_\s-]*not[_\s-]*found\b/i,
+  /\bmodel[_\s-]*decommissioned\b/i,
+  /\bdoes\s*not\s*exist\b/i,
+  /\bunknown\s*model\b/i,
+  /\binvalid\s*model\b/i,
+  /\bdeprecated\s*model\b/i,
+  /\bnot[_\s-]*found[_\s-]*error\b/i,
+  /\bno\s+such\s+model\b/i,
+  /\bmodel\b[^.]*\b(retired|sunset|discontinued|removed)\b/i,
+];
+
+/** Loose check whether an error message implies the model itself was rejected. */
+export function looksLikeModelError(error: unknown): boolean {
+  const msg = error instanceof Error ? error.message : String(error);
+  if (!msg) return false;
+  if (/\b404\b/.test(msg) && /\bmodel\b/i.test(msg)) return true;
+  return MODEL_ERROR_PATTERNS.some((re) => re.test(msg));
+}
+
+interface FallbackContext {
+  needsVision: boolean;
+  needsReasoning: boolean;
+  needsWebSearch: boolean;
+}
+
+function deriveContext(deadModel: string, providerId: string): FallbackContext {
+  const entry = getCatalogEntry(providerId, deadModel);
+  return {
+    needsVision: entry?.vision === true,
+    needsReasoning: entry?.reasoning === true,
+    needsWebSearch: entry?.webSearch === true,
+  };
+}
+
+/** Pick the closest live replacement for a discontinued model. */
+export function pickFallbackModel(
+  liveModels: ModelInfo[],
+  ctx: FallbackContext,
+): ModelInfo | null {
+  if (liveModels.length === 0) return null;
+
+  const score = (m: ModelInfo): number => {
+    let s = 0;
+    if (ctx.needsVision && m.vision === true) s += 8;
+    if (ctx.needsVision && m.vision === false) s -= 4;
+    if (ctx.needsReasoning && m.reasoning === true) s += 4;
+    if (ctx.needsWebSearch && m.webSearch === true) s += 2;
+    if (m.inputPrice != null) s += 1; // priced-in-catalog ≈ curated
+    return s;
+  };
+
+  const ranked = [...liveModels].sort((a, b) => score(b) - score(a));
+  return ranked[0] ?? null;
+}
+
+export interface DiscontinuationResult {
+  newConfig: ProviderConfig;
+  notice: MigrationNotice;
+}
+
+/**
+ * After an LLM call failure, verify whether the configured model has been
+ * discontinued by refreshing the provider's /models endpoint. If confirmed:
+ * persist the swap into settings (providerConfigs + discoveredDiscontinued +
+ * pendingMigrationNotices) and return the new config so the caller can retry.
+ *
+ * Returns null for any non-discontinuation error (transient, auth, network) —
+ * caller should rethrow the original error in that case.
+ */
+export async function handleDiscontinuationOnError(
+  error: unknown,
+  config: ProviderConfig,
+): Promise<DiscontinuationResult | null> {
+  if (!looksLikeModelError(error)) return null;
+  if (!config.apiKey && config.providerId !== 'self-hosted') return null;
+
+  let liveModels: ModelInfo[];
+  try {
+    liveModels = await fetchModels(config.providerId, config.apiKey, config.endpoint);
+  } catch {
+    // /models also failed — likely auth/network issue. Don't touch settings.
+    return null;
+  }
+
+  const stillThere = liveModels.some((m) => m.id === config.model);
+  if (stillThere) return null; // transient or non-model error
+
+  const ctx = deriveContext(config.model, config.providerId);
+  const fallback = pickFallbackModel(liveModels, ctx);
+  if (!fallback) return null;
+
+  const settings = await getSettings();
+  const existing = settings.providerConfigs[config.providerId] || config;
+  const newConfig: ProviderConfig = {
+    ...existing,
+    model: fallback.id,
+    contextWindow: fallback.contextWindow || existing.contextWindow,
+  };
+
+  const discoveredFor = new Set(settings.discoveredDiscontinued?.[config.providerId] ?? []);
+  discoveredFor.add(config.model);
+
+  const notice: MigrationNotice = {
+    providerId: config.providerId,
+    from: config.model,
+    to: fallback.id,
+    toName: fallback.name,
+    providerName: getProviderDefinition(config.providerId)?.name,
+    at: Date.now(),
+  };
+
+  await saveSettings({
+    providerConfigs: {
+      ...settings.providerConfigs,
+      [config.providerId]: newConfig,
+    },
+    discoveredDiscontinued: {
+      ...settings.discoveredDiscontinued,
+      [config.providerId]: [...discoveredFor],
+    },
+    pendingMigrationNotices: [...(settings.pendingMigrationNotices ?? []), notice],
+  });
+
+  return { newConfig, notice };
+}
+
+/** Set of models the runtime has confirmed are discontinued for this provider. */
+export function getDiscoveredDiscontinued(settings: Settings, providerId: string): Set<string> {
+  return new Set(settings.discoveredDiscontinued?.[providerId] ?? []);
+}

--- a/src/lib/llm/deprecation.ts
+++ b/src/lib/llm/deprecation.ts
@@ -1,8 +1,8 @@
 import type { ModelInfo, ProviderConfig } from './types';
-import type { MigrationNotice, Settings } from '../storage/types';
+import type { MigrationNotice } from '../storage/types';
 import { fetchModels, getCatalogEntry } from './models';
 import { getProviderDefinition } from './registry';
-import { getSettings, saveSettings } from '../storage/settings';
+import { saveSettings } from '../storage/settings';
 
 const MODEL_ERROR_PATTERNS = [
   /\bmodel[_\s-]*not[_\s-]*found\b/i,
@@ -133,9 +133,4 @@ export async function handleDiscontinuationOnError(
   });
 
   return { newConfig, notice };
-}
-
-/** Set of models the runtime has confirmed are discontinued for this provider. */
-export function getDiscoveredDiscontinued(settings: Settings, providerId: string): Set<string> {
-  return new Set(settings.discoveredDiscontinued?.[providerId] ?? []);
 }

--- a/src/lib/messaging/types.ts
+++ b/src/lib/messaging/types.ts
@@ -39,7 +39,9 @@ export type MessageType =
   | 'CLOSE_ONBOARDING_TABS'
   | 'CLOSE_ONBOARDING_TABS_RESULT'
   | 'IFRAME_COMMENTS'
-  | 'GENRE_CLASSIFIED';
+  | 'GENRE_CLASSIFIED'
+  | 'CLEAR_MIGRATION_NOTICES'
+  | 'CLEAR_MIGRATION_NOTICES_RESULT';
 
 export interface ExtractContentMessage {
   type: 'EXTRACT_CONTENT';
@@ -171,6 +173,17 @@ export interface SaveSettingsMessage {
 
 export interface SaveSettingsResultMessage {
   type: 'SAVE_SETTINGS_RESULT';
+  success: boolean;
+}
+
+export interface ClearMigrationNoticesMessage {
+  type: 'CLEAR_MIGRATION_NOTICES';
+  /** Timestamps (`MigrationNotice.at`) of the notices the side panel displayed. */
+  timestamps: number[];
+}
+
+export interface ClearMigrationNoticesResultMessage {
+  type: 'CLEAR_MIGRATION_NOTICES_RESULT';
   success: boolean;
 }
 
@@ -329,4 +342,6 @@ export type Message =
   | CloseOnboardingTabsMessage
   | CloseOnboardingTabsResultMessage
   | IframeCommentsMessage
-  | GenreClassifiedMessage;
+  | GenreClassifiedMessage
+  | ClearMigrationNoticesMessage
+  | ClearMigrationNoticesResultMessage;

--- a/src/lib/storage/settings.ts
+++ b/src/lib/storage/settings.ts
@@ -43,9 +43,22 @@ export async function getSettings(): Promise<Settings> {
   return { ...DEFAULT_SETTINGS, ...(stored as Partial<Settings>) };
 }
 
-export async function saveSettings(partial: Partial<Settings>): Promise<Settings> {
-  const current = await getSettings();
-  const updated = { ...current, ...partial };
-  await chromeStorage.local.set({ [STORAGE_KEY]: updated });
-  return updated;
+// Serialize concurrent writes within this process. chrome.storage doesn't expose
+// a CAS primitive, so two concurrent saveSettings() calls would each read-then-
+// write and the second one would clobber the first's mutations. Chaining keeps
+// every write atomic relative to other writes in this process.
+let writeQueue: Promise<unknown> = Promise.resolve();
+
+export async function saveSettings(
+  partial: Partial<Settings> | ((current: Settings) => Partial<Settings>),
+): Promise<Settings> {
+  const next = writeQueue.then(async () => {
+    const current = await getSettings();
+    const patch = typeof partial === 'function' ? partial(current) : partial;
+    const updated = { ...current, ...patch };
+    await chromeStorage.local.set({ [STORAGE_KEY]: updated });
+    return updated;
+  });
+  writeQueue = next.catch(() => undefined);
+  return next;
 }

--- a/src/lib/storage/types.ts
+++ b/src/lib/storage/types.ts
@@ -29,6 +29,21 @@ export interface Settings {
   enableImageAnalysis?: boolean;
   autoSearchFactCheck?: boolean;
   onboardingCompleted?: boolean;
+  /** Models the runtime confirmed are no longer offered by the provider. Per-provider lists. */
+  discoveredDiscontinued?: Record<string, string[]>;
+  /** One-shot notice shown after an automatic model swap; cleared once the side panel renders it. */
+  pendingMigrationNotices?: MigrationNotice[];
+}
+
+export interface MigrationNotice {
+  providerId: string;
+  from: string;
+  to: string;
+  /** Display name of the new model, when known. */
+  toName?: string;
+  /** Display name of the retired provider (e.g. "xAI (Grok)"), when known. */
+  providerName?: string;
+  at: number;
 }
 
 export const DEFAULT_SETTINGS: Settings = {


### PR DESCRIPTION
## Summary
- Detects provider-side model retirements at runtime: when an LLM call fails, re-fetches the provider's `/models` endpoint as the authoritative check. If `/models` succeeds and the configured model is absent, the model is confirmed discontinued.
- Auto-swaps to a capability-matched fallback (preserves vision / reasoning / web-search), persists the swap into `settings.providerConfigs[providerId].model`, and records the dead id in a new `settings.discoveredDiscontinued[providerId]` list so the picker hides it going forward.
- Surfaces a one-shot Toast in the side panel ("xAI retired grok-3-mini. Switched to Grok 4.1 Fast.") via a new `pendingMigrationNotices` field cleared on read.
- Wired into all four provider call paths: summarize, chat, test connection (auto-retries), probe vision.
- Provider-agnostic — covers xAI's May 15 retirements and any future deprecation across OpenAI / Anthropic / Google / DeepSeek without shipping catalog updates.

## Test plan
- [ ] Pick a model that's still live, run a summary — works as before.
- [ ] Manually edit `xtil_settings` in chrome.storage.local to set `providerConfigs.xai.model` to a retired id (e.g. `grok-3-mini`), trigger a summary — error message should say "xAI (Grok) retired grok-3-mini. Switched to <new model> — please try again." A second click summarizes successfully on the new model.
- [ ] Open Settings — the retired model is no longer in the dropdown.
- [ ] Reload the side panel — Toast announces the migration once, then doesn't reappear.
- [ ] With an invalid API key, the same flow does NOT mutate settings (since `/models` also fails — case 1 in the classifier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)