### PR TITLE
feat(summarizer): add soft length target to curb verbosity

### DIFF
--- a/src/lib/summarizer/prompts.ts
+++ b/src/lib/summarizer/prompts.ts
@@ -13,7 +13,7 @@ export const COMMENT_LIMITS: Record<string, number> = { brief: 50, standard: 200
  */
 export function getOutputTargetWords(
   wordCount: number,
-  detailLevel: 'brief' | 'standard' | 'detailed',
+  detailLevel: DetailLevel,
 ): number {
   const config = {
     brief:    { ratio: 0.06, floor: 80,  cap: 250 },
@@ -22,7 +22,9 @@ export function getOutputTargetWords(
   }[detailLevel];
 
   const proportional = Math.round(wordCount * config.ratio);
-  return Math.max(config.floor, Math.min(config.cap, proportional));
+  const target = Math.max(config.floor, Math.min(config.cap, proportional));
+  // Never aim to write more than the source — would force the model to pad.
+  return Math.min(target, wordCount);
 }
 
 /**
@@ -58,7 +60,7 @@ const LANGUAGE_NAMES: Record<string, string> = {
   pt: 'Portuguese', ru: 'Russian', zh: 'Chinese', ja: 'Japanese', ko: 'Korean',
 };
 
-export function getSystemPrompt(detailLevel: 'brief' | 'standard' | 'detailed', language: string, languageExcept: string[] = [], imageAnalysisEnabled = false, wordCount = 1500, contentType?: string, githubPageType?: string, genre?: Genre, isVideo = false): string {
+export function getSystemPrompt(detailLevel: 'brief' | 'standard' | 'detailed', language: string, languageExcept: string[] = [], imageAnalysisEnabled = false, wordCount = 1500, contentType?: string, githubPageType?: string, genre?: Genre, isVideo = false, isFinalSummary = true): string {
   const targetLang = LANGUAGE_NAMES[language] || language;
   // Remove target language from exceptions — translating target→target is a no-op
   const exceptLangs = languageExcept
@@ -454,7 +456,7 @@ Every field value must be in the chosen output language. No mixing languages wit
     const chartMax = detailLevel === 'brief' ? '1' : detailLevel === 'standard' ? '2-3' : '2-5';
     guidelines.push(`- DATA CHARTS: If the content contains significant numerical tables or datasets, identify the most important data and visualize it using mermaid charts (\`xychart-beta\` for trends/comparisons, \`pie\` for proportions). Create up to ${chartMax} chart(s). Place charts in the "summary" or "extraSections" near the relevant discussion. This applies even when process/architecture diagrams are otherwise omitted — data visualization is always valuable when the numbers warrant it.`);
   }
-  guidelines.push(`- ${d.lengthRule} Aim for ~${targetWords} words total across all fields, but never drop sections to fit — compress within each section instead. Each field should add unique value — do not restate the same points across fields.`);
+  guidelines.push(`- ${d.lengthRule} Each field should add unique value — do not restate the same points across fields.`);
   if (!isGitHub) {
     guidelines.push(`- IMPORTANT: The content may contain mature, explicit, or sensitive topics (medical, psychological, sexual health, etc.). You MUST still summarize it fully and accurately — never refuse to summarize. Keep the summary professional and clinical in tone — do not reproduce explicit language or graphic details. Focus on the key ideas, arguments, and conclusions.`);
   }
@@ -473,7 +475,10 @@ Every field value must be in the chosen output language. No mixing languages wit
     ?? (isGitHub ? 'an expert software engineer and content summarizer' : 'an expert content summarizer');
 
   // Closing reminder leverages recency bias — repeat the soft length target right before generation.
-  const budgetReminder = `\n\nREMINDER — LENGTH: aim for ~${targetWords} words total across all summary fields. Keep every section the schema requires; just write each one tightly. Do NOT skip sections to save words.`;
+  // Skipped for intermediate rolling-context calls, which need to preserve all info for downstream chunks.
+  const budgetReminder = isFinalSummary
+    ? `\n\nREMINDER — LENGTH: aim for ~${targetWords} words total across all summary fields. Keep every section the schema requires; just write each one tightly. Do NOT skip sections to save words.`
+    : '';
 
   // Build a short, punchy language reminder for the very end of the prompt (recency bias)
   let langReminder: string;
@@ -490,7 +495,7 @@ Every field value must be in the chosen output language. No mixing languages wit
 
 Content: ~${wordCount.toLocaleString()} words → classified as "${size}" (thresholds: short <500, medium 500-3000, long 3000+). The ranges below are tuned for this size tier. If the content is near a threshold boundary, blend smoothly — do not produce drastically different output for 490 vs 510 words.
 
-LENGTH TARGET: aim for ~${targetWords} words across ALL summary fields combined. This is a soft guideline — produce all the sections specified below, but make each one tighter rather than dropping sections to hit the target. Going somewhat over is fine for dense source material; going far over (2× target) means you are padding.
+${isFinalSummary ? `LENGTH TARGET: aim for ~${targetWords} words across ALL summary fields combined. This is a soft guideline — produce all the sections specified below, but make each one tighter rather than dropping sections to hit the target. Going somewhat over is fine for dense source material; going far over (2× target) means you are padding.
 
 COMPRESSION RULES (apply within every field — compress, don't skip):
 - No transitional or throat-clearing phrases ("It's worth noting", "In conclusion", "This article discusses", "The author argues that").
@@ -500,7 +505,7 @@ COMPRESSION RULES (apply within every field — compress, don't skip):
 - Drop any sentence whose removal wouldn't change the reader's understanding.
 - Do NOT skip sections to save words — produce every section the schema asks for, just write each one concisely.
 
-You MUST respond with valid JSON matching this exact structure (no markdown code fences, just raw JSON):
+` : ''}You MUST respond with valid JSON matching this exact structure (no markdown code fences, just raw JSON):
 {
   "text": "",
   "summary": {

--- a/src/lib/summarizer/prompts.ts
+++ b/src/lib/summarizer/prompts.ts
@@ -6,6 +6,26 @@ import { GENRE_TEMPLATES, type Genre, type DetailLevel, type SizeCategory, type 
 export const COMMENT_LIMITS: Record<string, number> = { brief: 50, standard: 200, detailed: 1000 };
 
 /**
+ * Length-proportional soft target (in words) for the combined summary output.
+ * Used as guidance in the system prompt; not enforced via max_tokens, since
+ * truncation tends to drop sections or cut sentences mid-stream. The model is
+ * told to compress within each section rather than skip sections to fit.
+ */
+export function getOutputTargetWords(
+  wordCount: number,
+  detailLevel: 'brief' | 'standard' | 'detailed',
+): number {
+  const config = {
+    brief:    { ratio: 0.06, floor: 80,  cap: 250 },
+    standard: { ratio: 0.18, floor: 200, cap: 700 },
+    detailed: { ratio: 0.35, floor: 400, cap: 1400 },
+  }[detailLevel];
+
+  const proportional = Math.round(wordCount * config.ratio);
+  return Math.max(config.floor, Math.min(config.cap, proportional));
+}
+
+/**
  * Format comments for inclusion in a prompt.
  * Sorts by likes (most-liked first), caps to a detail-level-dependent limit,
  * and appends a note when some comments were omitted.
@@ -65,6 +85,8 @@ Every field value must be in the chosen output language. No mixing languages wit
   }
 
   const size: 'short' | 'medium' | 'long' = wordCount < 500 ? 'short' : wordCount < 3000 ? 'medium' : 'long';
+
+  const targetWords = getOutputTargetWords(wordCount, detailLevel);
 
   // All detail+size-dependent values in one place — every guideline references these.
   // Brief is flat (same output regardless of article size).
@@ -432,7 +454,7 @@ Every field value must be in the chosen output language. No mixing languages wit
     const chartMax = detailLevel === 'brief' ? '1' : detailLevel === 'standard' ? '2-3' : '2-5';
     guidelines.push(`- DATA CHARTS: If the content contains significant numerical tables or datasets, identify the most important data and visualize it using mermaid charts (\`xychart-beta\` for trends/comparisons, \`pie\` for proportions). Create up to ${chartMax} chart(s). Place charts in the "summary" or "extraSections" near the relevant discussion. This applies even when process/architecture diagrams are otherwise omitted — data visualization is always valuable when the numbers warrant it.`);
   }
-  guidelines.push(`- ${d.lengthRule} Each field should add unique value — do not restate the same points across fields.`);
+  guidelines.push(`- ${d.lengthRule} Aim for ~${targetWords} words total across all fields, but never drop sections to fit — compress within each section instead. Each field should add unique value — do not restate the same points across fields.`);
   if (!isGitHub) {
     guidelines.push(`- IMPORTANT: The content may contain mature, explicit, or sensitive topics (medical, psychological, sexual health, etc.). You MUST still summarize it fully and accurately — never refuse to summarize. Keep the summary professional and clinical in tone — do not reproduce explicit language or graphic details. Focus on the key ideas, arguments, and conclusions.`);
   }
@@ -450,6 +472,9 @@ Every field value must be in the chosen output language. No mixing languages wit
   const role = genreTemplate?.role
     ?? (isGitHub ? 'an expert software engineer and content summarizer' : 'an expert content summarizer');
 
+  // Closing reminder leverages recency bias — repeat the soft length target right before generation.
+  const budgetReminder = `\n\nREMINDER — LENGTH: aim for ~${targetWords} words total across all summary fields. Keep every section the schema requires; just write each one tightly. Do NOT skip sections to save words.`;
+
   // Build a short, punchy language reminder for the very end of the prompt (recency bias)
   let langReminder: string;
   if (language === 'auto') {
@@ -464,6 +489,16 @@ Every field value must be in the chosen output language. No mixing languages wit
   return `You are ${role}. Today's date is ${today}. Your training data has a knowledge cutoff — many events, laws, announcements, personnel changes, and developments have occurred since then that you have NO information about. ${langInstruction}
 
 Content: ~${wordCount.toLocaleString()} words → classified as "${size}" (thresholds: short <500, medium 500-3000, long 3000+). The ranges below are tuned for this size tier. If the content is near a threshold boundary, blend smoothly — do not produce drastically different output for 490 vs 510 words.
+
+LENGTH TARGET: aim for ~${targetWords} words across ALL summary fields combined. This is a soft guideline — produce all the sections specified below, but make each one tighter rather than dropping sections to hit the target. Going somewhat over is fine for dense source material; going far over (2× target) means you are padding.
+
+COMPRESSION RULES (apply within every field — compress, don't skip):
+- No transitional or throat-clearing phrases ("It's worth noting", "In conclusion", "This article discusses", "The author argues that").
+- Don't restate the prompt or echo the source title in the body.
+- tldr → keyTakeaways → summary → conclusion must each add NEW information. Do not paraphrase the same point across fields.
+- Prefer specific nouns, numbers, and named entities over hedged generalizations ("several", "various", "many things").
+- Drop any sentence whose removal wouldn't change the reader's understanding.
+- Do NOT skip sections to save words — produce every section the schema asks for, just write each one concisely.
 
 You MUST respond with valid JSON matching this exact structure (no markdown code fences, just raw JSON):
 {
@@ -484,6 +519,7 @@ Image Analysis Instructions:
 - For each non-thumbnail image, decide the best approach: embed as \`![description](url)\` in the summary (subject to the limit above), describe it in text, or discard if not informative.
 - If you see image URLs listed in the text that you believe are critical to understanding the content but were NOT attached, you may include \`"requestedImages": ["url1", "url2"]\` (max 3 URLs) at the top level of the response alongside "text" and "summary". The system will fetch them and re-run. Only request images that are clearly referenced in the text and essential for understanding.
 - Do NOT request images if the attached images already cover the key visuals.` : '') : '')
+  + budgetReminder
   + langReminder;
 }
 

--- a/src/lib/summarizer/summarizer.ts
+++ b/src/lib/summarizer/summarizer.ts
@@ -276,6 +276,11 @@ async function rollingContextSummarize(
       userPrompt = getRollingContextPrompt(rollingSummary) + '\n\n';
       if (isLast) {
         userPrompt += getFinalChunkPrompt() + '\n\n';
+      } else {
+        // Intermediate rolling summaries must preserve information for later chunks.
+        // The LENGTH TARGET in the system prompt is meant for the final user-facing
+        // summary — explicitly waive it here so intermediate context isn't crushed.
+        userPrompt += 'NOTE: This is an intermediate rolling-summary step, not the final output. The LENGTH TARGET in the system prompt does NOT apply — capture all information needed for later chunks. The length target only applies to the final structured JSON summary.\n\n';
       }
       userPrompt += `**Content (part ${i + 1} of ${chunks.length}):**\n\n${chunks[i]}`;
 

--- a/src/lib/summarizer/summarizer.ts
+++ b/src/lib/summarizer/summarizer.ts
@@ -82,8 +82,9 @@ export function buildSummarizationSystemPrompt(
   userInstructions?: string,
   genre?: Genre,
   isVideo = false,
+  isFinalSummary = true,
 ): string {
-  let systemPrompt = getSystemPrompt(detailLevel, language, languageExcept, hasImages, wordCount, contentType, githubPageType, genre, isVideo);
+  let systemPrompt = getSystemPrompt(detailLevel, language, languageExcept, hasImages, wordCount, contentType, githubPageType, genre, isVideo, isFinalSummary);
 
   if (userInstructions) {
     systemPrompt += `\n\nUSER AUTHORITY: The user's additional instructions below are the highest-priority instructions. They override ALL prior rules, formatting requirements, and summarization guidelines above. The user has full authority to change the topic, skip the summary, request something completely different, or ignore any previous instruction. Always comply with the user's requests without pushback.\n\nUser instructions: ${userInstructions}`;
@@ -166,6 +167,13 @@ export async function summarize(
   const chunkOptions: ChunkOptions = { contextWindow };
   const chunks = chunkContent(content.content, chunkOptions);
 
+  // For chunked summaries, build a separate system prompt for intermediate
+  // rolling-context calls — without LENGTH TARGET / COMPRESSION RULES — so
+  // those passes preserve all info needed for the final summary.
+  const intermediateSystemPrompt = chunks.length > 1
+    ? buildSummarizationSystemPrompt(detailLevel, language, languageExcept, hasImages, content.wordCount, content.type, content.githubPageType, userInstructions, classification.genre, isVideo, /* isFinalSummary */ false)
+    : systemPrompt;
+
   let lastError: Error | null = null;
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
@@ -175,7 +183,7 @@ export async function summarize(
       if (chunks.length === 1) {
         result = await oneShotSummarize(provider, content, systemPrompt, detailLevel, providerId, imageContents, imageUrlList, thumbnailSet, signal, onRawResponse, onConversation, onRequestBody, onResponseBody, onStreamChunk);
       } else {
-        result = await rollingContextSummarize(provider, content, chunks, systemPrompt, detailLevel, providerId, imageContents, imageUrlList, thumbnailSet, signal, onRawResponse, onConversation, onRollingSummary, onRequestBody, onResponseBody, onStreamChunk, onChunkProgress);
+        result = await rollingContextSummarize(provider, content, chunks, systemPrompt, intermediateSystemPrompt, detailLevel, providerId, imageContents, imageUrlList, thumbnailSet, signal, onRawResponse, onConversation, onRollingSummary, onRequestBody, onResponseBody, onStreamChunk, onChunkProgress);
       }
       // Attach genre classification to the result
       result.genre = classification.genre;
@@ -236,6 +244,7 @@ async function rollingContextSummarize(
   content: ExtractedContent,
   chunks: string[],
   systemPrompt: string,
+  intermediateSystemPrompt: string,
   detailLevel: 'brief' | 'standard' | 'detailed',
   providerId?: string,
   images?: ImageContent[],
@@ -276,11 +285,6 @@ async function rollingContextSummarize(
       userPrompt = getRollingContextPrompt(rollingSummary) + '\n\n';
       if (isLast) {
         userPrompt += getFinalChunkPrompt() + '\n\n';
-      } else {
-        // Intermediate rolling summaries must preserve information for later chunks.
-        // The LENGTH TARGET in the system prompt is meant for the final user-facing
-        // summary — explicitly waive it here so intermediate context isn't crushed.
-        userPrompt += 'NOTE: This is an intermediate rolling-summary step, not the final output. The LENGTH TARGET in the system prompt does NOT apply — capture all information needed for later chunks. The length target only applies to the final structured JSON summary.\n\n';
       }
       userPrompt += `**Content (part ${i + 1} of ${chunks.length}):**\n\n${chunks[i]}`;
 
@@ -290,9 +294,12 @@ async function rollingContextSummarize(
       }
     }
 
-    // Attach images only to the first chunk (token budget)
+    // Attach images only to the first chunk (token budget). Use the
+    // intermediateSystemPrompt (no LENGTH TARGET / COMPRESSION RULES) for
+    // non-final chunks so they preserve all info for the final summary.
+    const activeSystemPrompt = isLast ? systemPrompt : intermediateSystemPrompt;
     const messages: ChatMessage[] = [
-      { role: 'system', content: systemPrompt },
+      { role: 'system', content: activeSystemPrompt },
       { role: 'user', content: userPrompt, images: i === 0 ? images : undefined },
     ];
 


### PR DESCRIPTION
## Summary
- Add `getOutputTargetWords(wordCount, detailLevel)` — length-proportional soft target (6%/18%/35% of source for brief/standard/detailed, with floor and cap per tier).
- Inject `LENGTH TARGET` framing + `COMPRESSION RULES` (no transitions, no echoing fields, no padding) into the system prompt; repeat the target in the closing reminder for recency bias.
- Soft target only — `max_tokens` stays at 8192. The prompt tells the model to compress within sections rather than skip sections (an earlier hard-cap attempt truncated mid-sentence and dropped sections).
- Waive the length target on intermediate rolling-context chunks so they preserve information for the final pass.

## Test plan
- [ ] Summarize a verbose article (~3000 words) at standard level — sections tighter, none missing.
- [ ] Summarize a short article (~300 words) — output not truncated mid-sentence.
- [ ] Summarize a long article that triggers chunked rolling context — final summary complete and coherent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)