### PR TITLE
fix(scripts): add LLM-parser fallback chain to update-model-catalog

### DIFF
--- a/scripts/update-model-catalog.mjs
+++ b/scripts/update-model-catalog.mjs
@@ -846,7 +846,7 @@ const DOC_PARSERS = [
         },
         body: JSON.stringify({
           model: 'gpt-4.1-mini',
-          max_completion_tokens: 4096,
+          max_tokens: 4096,
           messages: [{ role: 'user', content: prompt }],
           response_format: { type: 'json_object' },
         }),
@@ -870,7 +870,7 @@ const DOC_PARSERS = [
           'content-type': 'application/json',
         },
         body: JSON.stringify({
-          model: 'grok-4-1-fast-non-reasoning',
+          model: 'grok-4.3',
           max_tokens: 4096,
           messages: [{ role: 'user', content: prompt }],
           response_format: { type: 'json_object' },
@@ -932,6 +932,12 @@ ${docsText}`;
         continue;
       }
       const parsed = JSON.parse(jsonMatch[0]);
+      // Empty parse = success-but-useless; fall through to next provider.
+      // Otherwise a parser that returns {} silently short-circuits the chain.
+      if (Object.keys(parsed).length === 0) {
+        failures.push(`${parser.name}: parsed 0 models`);
+        continue;
+      }
       console.log(`  Parsed via ${parser.name} (${Object.keys(parsed).length} models)`);
       return parsed;
     } catch (err) {

--- a/scripts/update-model-catalog.mjs
+++ b/scripts/update-model-catalog.mjs
@@ -803,13 +803,90 @@ async function fetchDocPage(url) {
   }
 }
 
-async function parseDocsWithLLM(providerName, docsText) {
-  const anthropicKey = API_KEYS.anthropic;
-  if (!anthropicKey) {
-    console.warn('  No Anthropic API key, skipping LLM doc parsing');
-    return {};
-  }
+// Doc-parser providers, tried in order. Each entry runs the same prompt and
+// returns the model's text response (or throws on any non-2xx). The first
+// successful parse wins; if all fail, we return {} and let the warnings tell
+// the user. Multiple providers exist so a single dead key doesn't silently
+// kill the whole layer.
+const DOC_PARSERS = [
+  {
+    name: 'Anthropic',
+    keyEnv: 'anthropic',
+    call: async (apiKey, prompt) => {
+      const res = await fetch('https://api.anthropic.com/v1/messages', {
+        method: 'POST',
+        headers: {
+          'x-api-key': apiKey,
+          'anthropic-version': '2023-06-01',
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: 'claude-haiku-4-5-20251001',
+          max_tokens: 4096,
+          messages: [{ role: 'user', content: prompt }],
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.text().catch(() => '');
+        throw new Error(`${res.status} — ${body.slice(0, 300)}`);
+      }
+      const data = await res.json();
+      return data.content?.[0]?.text || '';
+    },
+  },
+  {
+    name: 'OpenAI',
+    keyEnv: 'openai',
+    call: async (apiKey, prompt) => {
+      const res = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: 'gpt-4.1-mini',
+          max_completion_tokens: 4096,
+          messages: [{ role: 'user', content: prompt }],
+          response_format: { type: 'json_object' },
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.text().catch(() => '');
+        throw new Error(`${res.status} — ${body.slice(0, 300)}`);
+      }
+      const data = await res.json();
+      return data.choices?.[0]?.message?.content || '';
+    },
+  },
+  {
+    name: 'xAI',
+    keyEnv: 'xai',
+    call: async (apiKey, prompt) => {
+      const res = await fetch('https://api.x.ai/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: 'grok-4-1-fast-non-reasoning',
+          max_tokens: 4096,
+          messages: [{ role: 'user', content: prompt }],
+          response_format: { type: 'json_object' },
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.text().catch(() => '');
+        throw new Error(`${res.status} — ${body.slice(0, 300)}`);
+      }
+      const data = await res.json();
+      return data.choices?.[0]?.message?.content || '';
+    },
+  },
+];
 
+async function parseDocsWithLLM(providerName, docsText) {
   const prompt = `You are extracting model metadata from a pricing/models documentation page for ${providerName}.
 
 Extract ALL models mentioned with their specifications. For each model, provide:
@@ -840,42 +917,29 @@ Respond with ONLY a JSON object mapping model IDs to their metadata. Omit fields
 Documentation text:
 ${docsText}`;
 
-  try {
-    const res = await fetch('https://api.anthropic.com/v1/messages', {
-      method: 'POST',
-      headers: {
-        'x-api-key': anthropicKey,
-        'anthropic-version': '2023-06-01',
-        'content-type': 'application/json',
-      },
-      body: JSON.stringify({
-        model: 'claude-haiku-4-5-20251001',
-        max_tokens: 4096,
-        messages: [{ role: 'user', content: prompt }],
-      }),
-    });
-
-    if (!res.ok) {
-      console.warn(`  LLM parse failed: ${res.status}`);
-      return {};
+  const failures = [];
+  for (const parser of DOC_PARSERS) {
+    const apiKey = API_KEYS[parser.keyEnv];
+    if (!apiKey) {
+      failures.push(`${parser.name}: no key`);
+      continue;
     }
-
-    const data = await res.json();
-    const text = data.content?.[0]?.text || '';
-
-    // Extract JSON from response (may be wrapped in markdown code blocks)
-    const jsonMatch = text.match(/\{[\s\S]*\}/);
-    if (!jsonMatch) {
-      console.warn('  LLM response had no JSON');
-      return {};
+    try {
+      const text = await parser.call(apiKey, prompt);
+      const jsonMatch = text.match(/\{[\s\S]*\}/);
+      if (!jsonMatch) {
+        failures.push(`${parser.name}: no JSON in response`);
+        continue;
+      }
+      const parsed = JSON.parse(jsonMatch[0]);
+      console.log(`  Parsed via ${parser.name} (${Object.keys(parsed).length} models)`);
+      return parsed;
+    } catch (err) {
+      failures.push(`${parser.name}: ${err.message}`);
     }
-
-    const parsed = JSON.parse(jsonMatch[0]);
-    return parsed;
-  } catch (err) {
-    console.warn(`  LLM parse error: ${err.message}`);
-    return {};
   }
+  console.warn(`  LLM parse failed across all providers — ${failures.join(' | ')}`);
+  return {};
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/llm/model-catalog-raw.json
+++ b/src/lib/llm/model-catalog-raw.json
@@ -1,5 +1,5 @@
 {
-  "_generated": "2026-05-07T06:38:49.895Z",
+  "_generated": "2026-05-07T15:34:41.254Z",
   "providers": {
     "anthropic": {
       "models": {
@@ -42,8 +42,8 @@
           "inputPrice": 1,
           "outputPrice": 5,
           "vision": true,
-          "reasoning": false,
-          "webSearch": true
+          "reasoning": true,
+          "webSearch": false
         },
         "claude-opus-4-1-20250805": {
           "name": "Claude Opus 4.1",
@@ -79,8 +79,13 @@
         },
         "claude-opus-4-7": {
           "name": "Claude Opus 4.7",
-          "reasoning": false,
-          "webSearch": true
+          "contextWindow": 1000000,
+          "maxOutput": 128000,
+          "inputPrice": 5,
+          "outputPrice": 25,
+          "vision": true,
+          "reasoning": true,
+          "webSearch": false
         },
         "claude-sonnet-4-20250514": {
           "name": "Claude Sonnet 4",
@@ -100,13 +105,13 @@
         },
         "claude-sonnet-4-6": {
           "name": "Claude Sonnet 4.6",
-          "contextWindow": 200000,
+          "contextWindow": 1000000,
           "maxOutput": 64000,
           "inputPrice": 3,
           "outputPrice": 15,
           "vision": true,
-          "reasoning": false,
-          "webSearch": true
+          "reasoning": true,
+          "webSearch": false
         }
       }
     },
@@ -130,12 +135,24 @@
           "reasoning": true
         },
         "deepseek-v4-flash": {
-          "reasoning": false,
-          "name": "deepseek-v4-flash"
+          "name": "DeepSeek V4 Flash",
+          "contextWindow": 1000000,
+          "maxOutput": 384000,
+          "inputPrice": 0.0028,
+          "outputPrice": 0.28,
+          "vision": false,
+          "reasoning": true,
+          "webSearch": false
         },
         "deepseek-v4-pro": {
+          "name": "DeepSeek V4 Pro",
+          "contextWindow": 1000000,
+          "maxOutput": 384000,
+          "inputPrice": 0.0145,
+          "outputPrice": 3.48,
+          "vision": false,
           "reasoning": true,
-          "name": "deepseek-v4-pro"
+          "webSearch": false
         }
       }
     },
@@ -299,6 +316,11 @@
           "contextWindow": 65536,
           "maxOutput": 65536
         },
+        "gemini-3.1-flash-lite": {
+          "name": "Gemini 3.1 Flash Lite",
+          "contextWindow": 1048576,
+          "maxOutput": 65536
+        },
         "gemini-3.1-flash-lite-preview": {
           "name": "Gemini 3.1 Flash Lite Preview",
           "contextWindow": 1048576,
@@ -377,6 +399,14 @@
     },
     "openai": {
       "models": {
+        "chat-latest": {
+          "name": "ChatGPT Chat Latest",
+          "inputPrice": 5,
+          "outputPrice": 30,
+          "vision": false,
+          "reasoning": true,
+          "webSearch": true
+        },
         "chatgpt-4o-latest": {
           "name": "ChatGPT-4o Latest",
           "contextWindow": 128000,
@@ -388,6 +418,14 @@
         },
         "chatgpt-image-latest": {
           "name": "chatgpt-image-latest"
+        },
+        "computer-use-preview": {
+          "name": "Computer Use Preview",
+          "inputPrice": 1.5,
+          "outputPrice": 6,
+          "vision": false,
+          "reasoning": false,
+          "webSearch": false
         },
         "gpt-3.5-turbo": {
           "name": "gpt-3.5-turbo"
@@ -518,7 +556,12 @@
           "name": "gpt-4o-mini-search-preview-2025-03-11"
         },
         "gpt-4o-mini-transcribe": {
-          "name": "gpt-4o-mini-transcribe"
+          "name": "GPT-4o Mini Transcribe",
+          "inputPrice": 1.25,
+          "outputPrice": 5,
+          "vision": false,
+          "reasoning": false,
+          "webSearch": false
         },
         "gpt-4o-mini-transcribe-2025-03-20": {
           "name": "gpt-4o-mini-transcribe-2025-03-20"
@@ -551,7 +594,12 @@
           "name": "gpt-4o-search-preview-2025-03-11"
         },
         "gpt-4o-transcribe": {
-          "name": "gpt-4o-transcribe"
+          "name": "GPT-4o Transcribe",
+          "inputPrice": 2.5,
+          "outputPrice": 10,
+          "vision": false,
+          "reasoning": false,
+          "webSearch": false
         },
         "gpt-4o-transcribe-diarize": {
           "name": "gpt-4o-transcribe-diarize"
@@ -681,48 +729,75 @@
           "name": "gpt-5.3-chat-latest"
         },
         "gpt-5.3-codex": {
-          "name": "gpt-5.3-codex"
+          "name": "GPT-5.3 Codex",
+          "inputPrice": 1.75,
+          "outputPrice": 14,
+          "vision": false,
+          "reasoning": false,
+          "webSearch": false
         },
         "gpt-5.4": {
+          "name": "GPT-5.4",
+          "inputPrice": 1.25,
+          "outputPrice": 7.5,
+          "vision": false,
           "reasoning": true,
-          "webSearch": true,
-          "name": "gpt-5.4"
+          "webSearch": true
         },
         "gpt-5.4-2026-03-05": {
           "name": "gpt-5.4-2026-03-05"
         },
         "gpt-5.4-mini": {
+          "name": "GPT-5.4 Mini",
+          "inputPrice": 0.375,
+          "outputPrice": 2.25,
+          "vision": false,
           "reasoning": true,
-          "webSearch": true,
-          "name": "gpt-5.4-mini"
+          "webSearch": true
         },
         "gpt-5.4-mini-2026-03-17": {
           "name": "gpt-5.4-mini-2026-03-17"
         },
         "gpt-5.4-nano": {
+          "name": "GPT-5.4 Nano",
+          "inputPrice": 0.1,
+          "outputPrice": 0.625,
+          "vision": false,
           "reasoning": true,
-          "webSearch": true,
-          "name": "gpt-5.4-nano"
+          "webSearch": true
         },
         "gpt-5.4-nano-2026-03-17": {
           "name": "gpt-5.4-nano-2026-03-17"
         },
         "gpt-5.4-pro": {
-          "name": "gpt-5.4-pro"
+          "name": "GPT-5.4 Pro",
+          "inputPrice": 15,
+          "outputPrice": 90,
+          "vision": false,
+          "reasoning": true,
+          "webSearch": true
         },
         "gpt-5.4-pro-2026-03-05": {
           "name": "gpt-5.4-pro-2026-03-05"
         },
         "gpt-5.5": {
+          "name": "GPT-5.5",
+          "inputPrice": 2.5,
+          "outputPrice": 15,
+          "vision": false,
           "reasoning": true,
-          "webSearch": true,
-          "name": "gpt-5.5"
+          "webSearch": true
         },
         "gpt-5.5-2026-04-23": {
           "name": "gpt-5.5-2026-04-23"
         },
         "gpt-5.5-pro": {
-          "name": "gpt-5.5-pro"
+          "name": "GPT-5.5 Pro",
+          "inputPrice": 15,
+          "outputPrice": 90,
+          "vision": false,
+          "reasoning": true,
+          "webSearch": true
         },
         "gpt-5.5-pro-2026-04-23": {
           "name": "gpt-5.5-pro-2026-04-23"
@@ -749,13 +824,26 @@
           "name": "gpt-image-1"
         },
         "gpt-image-1-mini": {
-          "name": "gpt-image-1-mini"
+          "name": "GPT Image 1 Mini",
+          "inputPrice": 2,
+          "vision": true,
+          "reasoning": false,
+          "webSearch": false
         },
         "gpt-image-1.5": {
-          "name": "gpt-image-1.5"
+          "name": "GPT Image 1.5",
+          "inputPrice": 5,
+          "outputPrice": 10,
+          "vision": true,
+          "reasoning": false,
+          "webSearch": false
         },
         "gpt-image-2": {
-          "name": "gpt-image-2"
+          "name": "GPT Image 2",
+          "inputPrice": 5,
+          "vision": true,
+          "reasoning": false,
+          "webSearch": false
         },
         "gpt-image-2-2026-04-21": {
           "name": "gpt-image-2-2026-04-21"
@@ -764,13 +852,23 @@
           "name": "gpt-realtime"
         },
         "gpt-realtime-1.5": {
-          "name": "gpt-realtime-1.5"
+          "name": "GPT Realtime 1.5",
+          "inputPrice": 4,
+          "outputPrice": 16,
+          "vision": true,
+          "reasoning": false,
+          "webSearch": false
         },
         "gpt-realtime-2025-08-28": {
           "name": "gpt-realtime-2025-08-28"
         },
         "gpt-realtime-mini": {
-          "name": "gpt-realtime-mini"
+          "name": "GPT Realtime Mini",
+          "inputPrice": 0.6,
+          "outputPrice": 2.4,
+          "vision": true,
+          "reasoning": false,
+          "webSearch": false
         },
         "gpt-realtime-mini-2025-10-06": {
           "name": "gpt-realtime-mini-2025-10-06"
@@ -827,7 +925,12 @@
           "name": "o3-2025-04-16"
         },
         "o3-deep-research": {
-          "name": "o3-deep-research"
+          "name": "O3 Deep Research",
+          "inputPrice": 5,
+          "outputPrice": 20,
+          "vision": false,
+          "reasoning": true,
+          "webSearch": false
         },
         "o3-deep-research-2025-06-26": {
           "name": "o3-deep-research-2025-06-26"
@@ -868,13 +971,31 @@
           "webSearch": true
         },
         "o4-mini-2025-04-16": {
-          "name": "o4-mini-2025-04-16"
+          "name": "O4 Mini 2025-04-16",
+          "inputPrice": 4,
+          "outputPrice": 16,
+          "vision": false,
+          "reasoning": true,
+          "webSearch": false
         },
         "o4-mini-deep-research": {
-          "name": "o4-mini-deep-research"
+          "name": "O4 Mini Deep Research",
+          "inputPrice": 1,
+          "outputPrice": 4,
+          "vision": false,
+          "reasoning": true,
+          "webSearch": false
         },
         "o4-mini-deep-research-2025-06-26": {
           "name": "o4-mini-deep-research-2025-06-26"
+        },
+        "sora-2": {
+          "name": "Sora 2",
+          "vision": true
+        },
+        "sora-2-pro": {
+          "name": "Sora 2 Pro",
+          "vision": true
         }
       }
     },
@@ -932,23 +1053,26 @@
           "webSearch": true
         },
         "grok-4-1-fast-non-reasoning": {
-          "name": "Grok 4.1 Fast (Non-Reasoning)",
-          "contextWindow": 2097152,
+          "name": "Grok 4.1 Fast Non-Reasoning",
+          "contextWindow": 2000000,
           "inputPrice": 0.2,
           "outputPrice": 0.5,
-          "vision": true,
+          "vision": false,
           "textGeneration": true,
-          "webSearch": true
+          "webSearch": false,
+          "maxOutput": 2000000,
+          "reasoning": false
         },
         "grok-4-1-fast-reasoning": {
-          "name": "Grok 4.1 Fast (Reasoning)",
-          "contextWindow": 2097152,
+          "name": "Grok 4.1 Fast Reasoning",
+          "contextWindow": 2000000,
           "inputPrice": 0.2,
           "outputPrice": 0.5,
-          "vision": true,
+          "vision": false,
           "textGeneration": true,
           "reasoning": true,
-          "webSearch": true
+          "webSearch": false,
+          "maxOutput": 2000000
         },
         "grok-4-fast-non-reasoning": {
           "name": "Grok 4 Fast (Non-Reasoning)",
@@ -970,18 +1094,44 @@
           "webSearch": true
         },
         "grok-4.20-0309-non-reasoning": {
-          "name": "grok-4.20-0309-non-reasoning"
+          "name": "Grok 4.20 0309 Non-Reasoning",
+          "contextWindow": 2000000,
+          "maxOutput": 2000000,
+          "inputPrice": 1.25,
+          "outputPrice": 2.5,
+          "vision": false,
+          "reasoning": false,
+          "webSearch": false
         },
         "grok-4.20-0309-reasoning": {
+          "name": "Grok 4.20 0309 Reasoning",
+          "contextWindow": 2000000,
+          "maxOutput": 2000000,
+          "inputPrice": 1.25,
+          "outputPrice": 2.5,
+          "vision": false,
           "reasoning": true,
-          "webSearch": true,
-          "name": "grok-4.20-0309-reasoning"
+          "webSearch": false
         },
         "grok-4.20-multi-agent-0309": {
-          "name": "grok-4.20-multi-agent-0309"
+          "name": "Grok 4.20 Multi-Agent 0309",
+          "contextWindow": 2000000,
+          "maxOutput": 2000000,
+          "inputPrice": 1.25,
+          "outputPrice": 2.5,
+          "vision": false,
+          "reasoning": true,
+          "webSearch": false
         },
         "grok-4.3": {
-          "name": "grok-4.3"
+          "name": "Grok 4.3",
+          "contextWindow": 1000000,
+          "maxOutput": 1000000,
+          "inputPrice": 1.25,
+          "outputPrice": 2.5,
+          "vision": false,
+          "reasoning": true,
+          "webSearch": false
         },
         "grok-code-fast-1": {
           "name": "Grok Code Fast 1",
@@ -993,21 +1143,26 @@
         },
         "grok-imagine-image": {
           "name": "Grok Imagine Image",
-          "vision": false,
-          "textGeneration": false
+          "vision": true,
+          "textGeneration": false,
+          "inputPrice": 0.02
         },
         "grok-imagine-image-pro": {
           "name": "Grok Imagine Image Pro",
-          "vision": false,
-          "textGeneration": false
+          "vision": true,
+          "textGeneration": false,
+          "inputPrice": 0.07
         },
         "grok-imagine-image-quality": {
-          "name": "grok-imagine-image-quality"
+          "name": "Grok Imagine Image Quality",
+          "inputPrice": 0.05,
+          "vision": true
         },
         "grok-imagine-video": {
           "name": "Grok Imagine Video",
-          "vision": false,
-          "textGeneration": false
+          "vision": true,
+          "textGeneration": false,
+          "inputPrice": 0.05
         }
       }
     }

--- a/src/lib/llm/model-catalog.json
+++ b/src/lib/llm/model-catalog.json
@@ -1,5 +1,5 @@
 {
-  "_generated": "2026-05-06T00:00:00.000Z",
+  "_generated": "2026-05-07T00:00:00.000Z",
   "providers": {
     "anthropic": {
       "models": {
@@ -10,7 +10,7 @@
           "inputPrice": 1,
           "outputPrice": 5,
           "vision": true,
-          "reasoning": false,
+          "reasoning": true,
           "webSearch": true
         },
         "claude-sonnet-4-6": {
@@ -20,7 +20,7 @@
           "inputPrice": 3,
           "outputPrice": 15,
           "vision": true,
-          "reasoning": false,
+          "reasoning": true,
           "webSearch": true
         },
         "claude-3-haiku-20240307": {
@@ -38,7 +38,7 @@
           "inputPrice": 5,
           "outputPrice": 25,
           "vision": true,
-          "reasoning": false,
+          "reasoning": true,
           "webSearch": true
         }
       },
@@ -140,6 +140,7 @@
         "gemini-2.0-flash-lite-001",
         "gemini-2.5-computer-use-preview-10-2025",
         "gemini-3-pro-preview",
+        "gemini-3.1-flash-lite",
         "gemini-3.1-pro-preview-customtools",
         "gemini-flash-latest",
         "gemini-flash-lite-latest",
@@ -248,7 +249,9 @@
         }
       },
       "excluded": [
+        "chat-latest",
         "chatgpt-4o-latest",
+        "computer-use-preview",
         "gpt-3.5-turbo",
         "gpt-3.5-turbo-16k",
         "gpt-4",
@@ -280,11 +283,24 @@
         "o3-deep-research",
         "o3-mini",
         "o3-pro",
-        "o4-mini-deep-research"
+        "o4-mini-deep-research",
+        "sora-2",
+        "sora-2-pro"
       ]
     },
     "xai": {
       "models": {
+        "grok-4.3": {
+          "name": "Grok 4.3",
+          "contextWindow": 1000000,
+          "maxOutput": 1000000,
+          "inputPrice": 1.25,
+          "outputPrice": 2.5,
+          "vision": true,
+          "textGeneration": true,
+          "reasoning": true,
+          "webSearch": true
+        },
         "grok-4.20-0309-reasoning": {
           "name": "Grok 4.20 (Reasoning)",
           "contextWindow": 2000000,
@@ -294,25 +310,6 @@
           "textGeneration": true,
           "reasoning": true,
           "webSearch": true
-        },
-        "grok-4-1-fast-reasoning": {
-          "name": "Grok 4.1 Fast (Reasoning)",
-          "contextWindow": 2097152,
-          "inputPrice": 0.2,
-          "outputPrice": 0.5,
-          "vision": true,
-          "textGeneration": true,
-          "reasoning": true,
-          "webSearch": true
-        },
-        "grok-4-1-fast-non-reasoning": {
-          "name": "Grok 4.1 Fast (Non-Reasoning)",
-          "contextWindow": 2097152,
-          "inputPrice": 0.2,
-          "outputPrice": 0.5,
-          "vision": true,
-          "textGeneration": true,
-          "webSearch": true
         }
       },
       "excluded": [
@@ -321,11 +318,12 @@
         "grok-3-mini",
         "grok-4",
         "grok-4-0709",
+        "grok-4-1-fast-non-reasoning",
+        "grok-4-1-fast-reasoning",
         "grok-4-fast-non-reasoning",
         "grok-4-fast-reasoning",
         "grok-4.20-0309-non-reasoning",
         "grok-4.20-multi-agent-0309",
-        "grok-4.3",
         "grok-code-fast-1"
       ]
     }


### PR DESCRIPTION
## Summary
- The catalog updater silently degraded when its sole doc-parser (Anthropic) returned a 4xx — the script swallowed the status code and continued with an empty docs layer. Newly-listed models like Grok 4.3 came through API listings with only an ID and no pricing/context/capabilities, then dropped at the curation step.
- Try **Anthropic → OpenAI → xAI** in order; first 2xx wins. A single dead key no longer disables the whole layer.
- Print the response body when a parser returns non-2xx (was just status code), so causes like *"organization has been disabled"* are visible.
- Refresh the curated catalog: add **Grok 4.3** (1M context, \$1.25/\$2.50, vision/reasoning/web-search) as the xAI flagship; move `grok-4-1-fast-*` to excluded ahead of xAI's May 15 retirement; pick up specs for the new GPT-5.4/5.5 family, DeepSeek V4 Pro, and Anthropic reasoning capabilities.

## Test plan
- [ ] \`node scripts/update-model-catalog.mjs --provider=xai --dry-run\` — confirms it falls through to OpenAI when Anthropic returns 400 and parses 10 xAI models
- [ ] \`pnpm wxt build\` — clean
- [ ] After release, verify Grok 4.3 appears in the model picker with the correct pricing

🤖 Generated with [Claude Code](https://claude.com/claude-code)