### PR TITLE
feat(llm): default xAI to Responses API for auto-caching

### DIFF
--- a/src/lib/llm/provider.ts
+++ b/src/lib/llm/provider.ts
@@ -89,30 +89,66 @@ export class OpenAICompatibleProvider implements LLMProvider {
   }
 
   /**
-   * Responses API — used for web search on OpenAI and xAI.
-   * OpenAI: web_search_preview tool; xAI: web_search tool.
-   * Chat Completions API only supports 'function'/'custom' tool types.
+   * Responses API routing:
+   * - OpenAI: only for web search (Chat Completions handles everything else fine).
+   * - xAI: default for everything (auto-caching, off the deprecated Chat Completions path),
+   *   except when any message carries images — xAI Responses API is text-only.
    */
-  private async sendResponsesApi(messages: ChatMessage[], options?: ChatOptions): Promise<string> {
-    const url = `${this.endpoint}/v1/responses`;
-    // Separate system messages into `instructions`, rest into `input`
+  private shouldUseResponsesApi(messages: ChatMessage[], options?: ChatOptions): boolean {
+    if (this.isOpenAI) return options?.webSearch === true;
+    if (this.id === 'xai') return !messages.some(m => m.images?.length);
+    return false;
+  }
+
+  /**
+   * Build the Responses API request body. Shared between non-streaming and streaming paths.
+   * Routes JSON mode/schema through `text.format`, web search through `tools`, and
+   * caps output via `max_output_tokens` (Responses-API native).
+   */
+  private buildResponsesBody(messages: ChatMessage[], options: ChatOptions | undefined, stream: boolean): Record<string, unknown> {
     const instructions = messages
       .filter(m => m.role === 'system')
       .map(m => m.content)
       .join('\n\n') || undefined;
     // OpenAI Responses API uses different content part types (input_text/input_image);
-    // xAI Responses API doesn't support multi-part content at all — text only.
+    // xAI Responses API is text-only — image-bearing messages are routed elsewhere.
     const input = messages
       .filter(m => m.role !== 'system')
       .map(m => this.isOpenAI ? this.formatResponsesMessage(m) : ({ role: m.role, content: m.content }));
 
-    const searchTool = this.isOpenAI ? 'web_search_preview' : 'web_search';
     const body: Record<string, unknown> = {
       model: this.config.model,
       input,
-      tools: [{ type: searchTool }],
+      stream,
     };
     if (instructions) body.instructions = instructions;
+    if (options?.webSearch) {
+      body.tools = [{ type: this.isOpenAI ? 'web_search_preview' : 'web_search' }];
+    }
+    if (options?.maxTokens) body.max_output_tokens = options.maxTokens;
+    if (!this.isReasoning) body.temperature = options?.temperature ?? 0.3;
+    if (options?.jsonSchema) {
+      body.text = {
+        format: {
+          type: 'json_schema',
+          name: options.jsonSchema.name,
+          schema: options.jsonSchema.schema,
+          strict: false,
+        },
+      };
+    } else if (options?.jsonMode) {
+      body.text = { format: { type: 'json_object' } };
+    }
+    return body;
+  }
+
+  /**
+   * Non-streaming Responses API call. Default path for xAI (auto-caching) and the
+   * web-search path for OpenAI. xAI: web_search tool; OpenAI: web_search_preview.
+   */
+  private async sendResponsesApi(messages: ChatMessage[], options?: ChatOptions): Promise<string> {
+    const url = `${this.endpoint}/v1/responses`;
+    const body = this.buildResponsesBody(messages, options, false);
 
     const timeoutController = new AbortController();
     const timer = setTimeout(() => timeoutController.abort(), 120_000);
@@ -163,9 +199,48 @@ export class OpenAICompatibleProvider implements LLMProvider {
     }
   }
 
+  /**
+   * Streaming Responses API call. Yields output_text deltas as they arrive.
+   * Matches OpenAI's Responses API SSE event spec, which xAI mirrors.
+   */
+  private async *streamResponsesApi(messages: ChatMessage[], options?: ChatOptions): AsyncGenerator<string> {
+    const url = `${this.endpoint}/v1/responses`;
+    const body = this.buildResponsesBody(messages, options, true);
+    const bodyJson = JSON.stringify(body);
+    options?.onRequestBody?.(bodyJson);
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.config.apiKey}`,
+      },
+      body: bodyJson,
+      signal: options?.signal,
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(parseApiError(response.status, errorText));
+    }
+
+    let accumulated = '';
+    try {
+      for await (const evt of parseResponsesSSEStream(response)) {
+        if (evt.type === 'response.output_text.delta' && typeof evt.delta === 'string') {
+          accumulated += evt.delta;
+          yield evt.delta;
+        }
+      }
+    } finally {
+      if (accumulated) {
+        options?.onResponseBody?.(JSON.stringify({ output_text: accumulated }));
+      }
+    }
+  }
+
   async sendChat(messages: ChatMessage[], options?: ChatOptions): Promise<string> {
-    // OpenAI & xAI web search requires the Responses API (not Chat Completions)
-    if (options?.webSearch && (this.isOpenAI || this.id === 'xai')) {
+    if (this.shouldUseResponsesApi(messages, options)) {
       return this.sendResponsesApi(messages, options);
     }
 
@@ -226,10 +301,8 @@ export class OpenAICompatibleProvider implements LLMProvider {
   }
 
   async *streamChat(messages: ChatMessage[], options?: ChatOptions): AsyncGenerator<string> {
-    // OpenAI & xAI web search requires the Responses API (non-streaming)
-    if (options?.webSearch && (this.isOpenAI || this.id === 'xai')) {
-      const result = await this.sendResponsesApi(messages, options);
-      yield result;
+    if (this.shouldUseResponsesApi(messages, options)) {
+      yield* this.streamResponsesApi(messages, options);
       return;
     }
 
@@ -289,6 +362,44 @@ export class OpenAICompatibleProvider implements LLMProvider {
     } catch {
       return false;
     }
+  }
+}
+
+/**
+ * Parse Responses-API SSE stream into typed events. Yields each `data:` JSON event
+ * untouched so callers can dispatch on `type` (response.output_text.delta, etc.).
+ */
+export async function* parseResponsesSSEStream(response: Response): AsyncGenerator<Record<string, unknown>> {
+  const reader = response.body?.getReader();
+  if (!reader) throw new Error('No response body');
+
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || '';
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || !trimmed.startsWith('data: ')) continue;
+        const data = trimmed.slice(6);
+        if (data === '[DONE]') return;
+
+        try {
+          yield JSON.parse(data);
+        } catch {
+          // skip malformed JSON lines
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
   }
 }
 

--- a/src/lib/llm/provider.ts
+++ b/src/lib/llm/provider.ts
@@ -209,30 +209,43 @@ export class OpenAICompatibleProvider implements LLMProvider {
     const bodyJson = JSON.stringify(body);
     options?.onRequestBody?.(bodyJson);
 
-    const response = await fetch(url, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${this.config.apiKey}`,
-      },
-      body: bodyJson,
-      signal: options?.signal,
-    });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      throw new Error(parseApiError(response.status, errorText));
-    }
+    const timeoutController = new AbortController();
+    const timer = setTimeout(() => timeoutController.abort(), 120_000);
+    const signal = options?.signal
+      ? AbortSignal.any([timeoutController.signal, options.signal])
+      : timeoutController.signal;
 
     let accumulated = '';
     try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${this.config.apiKey}`,
+        },
+        body: bodyJson,
+        signal,
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(parseApiError(response.status, errorText));
+      }
+
       for await (const evt of parseResponsesSSEStream(response)) {
         if (evt.type === 'response.output_text.delta' && typeof evt.delta === 'string') {
           accumulated += evt.delta;
           yield evt.delta;
         }
       }
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') {
+        if (options?.signal?.aborted) throw new Error('Summarization cancelled');
+        throw new Error('LLM request timed out after 120s');
+      }
+      throw err;
     } finally {
+      clearTimeout(timer);
       if (accumulated) {
         options?.onResponseBody?.(JSON.stringify({ output_text: accumulated }));
       }

--- a/src/lib/llm/provider.ts
+++ b/src/lib/llm/provider.ts
@@ -302,6 +302,13 @@ export class OpenAICompatibleProvider implements LLMProvider {
 
   async *streamChat(messages: ChatMessage[], options?: ChatOptions): AsyncGenerator<string> {
     if (this.shouldUseResponsesApi(messages, options)) {
+      // Web search returns inline <grok:render> citation tags that we strip on the
+      // full response. Per-delta stripping would corrupt tags that span chunks, so
+      // fall back to non-streaming for that path (matches pre-PR behaviour).
+      if (options?.webSearch) {
+        yield await this.sendResponsesApi(messages, options);
+        return;
+      }
       yield* this.streamResponsesApi(messages, options);
       return;
     }


### PR DESCRIPTION
## Summary

xAI now flags Chat Completions as **deprecated** ([comparison docs](https://docs.x.ai/developers/model-capabilities/text/comparison)) — "legacy endpoint, limited updates" with new features delivered to Responses API first. This PR routes all non-image xAI calls through `/v1/responses`.

**Headline win: automatic conversation caching.** Grok 4.3 prices cached prompt tokens at \$0.20/M vs \$1.25/M uncached — a 6× saving on the repeated system prompts that dominate summarization workloads. We also pick up encrypted reasoning content support (Chat Completions only exposed `reasoning_content` for grok-3-mini).

### Changes

- **`shouldUseResponsesApi()`** routes xAI to Responses API by default, falling back to Chat Completions only when a message carries images (xAI Responses API is text-only — image-bearing messages still need `/v1/chat/completions`).
- **`buildResponsesBody()`** shared between non-streaming and streaming paths. Translates our common options:
  - `jsonSchema` / `jsonMode` → `text.format` (Responses-API native)
  - `webSearch` → `tools: [{ type: 'web_search' }]`
  - `maxTokens` → `max_output_tokens`
  - `temperature` skipped for reasoning models (unchanged)
- **`streamResponsesApi()`** new — yields real `response.output_text.delta` events with a 120s timeout watchdog and AbortError translation. Previously web-search streams collapsed to a single yield via the non-streaming path; the no-search xAI path now streams all the way through.
- **`parseResponsesSSEStream()`** helper yields raw events; caller dispatches on `type`.

### OpenAI behaviour change (subtle)

OpenAI is still routed to Responses API only for web search, **but the request body now includes** `temperature` (default 0.3) and `max_output_tokens` (8192 from the summarizer) — pre-PR these fields were absent from `sendResponsesApi`, so OpenAI used model defaults. This brings OpenAI web-search calls in line with `sendChat` (which always sets them). Lower temperature is also a sensible default for the fact-check use case that drives most web-search traffic.

### Streaming + web search

`streamChat` falls back to non-streaming `sendResponsesApi` when `webSearch` is true so `<grok:render>` citation tags get stripped before yielding (per-delta stripping would corrupt tags spanning chunks). Real streaming applies to the no-web-search xAI calls — which is where the auto-caching benefit lives.

### Risks & known gaps

- xAI docs confirm `stream: true` and `[DONE]` terminator but don't spec exact event types. We assume OpenAI parity (`response.output_text.delta` with a `delta` field) — if xAI emits a different shape, output will be empty rather than wrong.
- `text.format` JSON-schema/JSON-mode shape is unverified against xAI's live API; matches OpenAI's spec which xAI generally mirrors.
- Image-bearing xAI messages (rare — only the vision analysis pipeline) still go through Chat Completions.

## Test plan

- [ ] Plain summarization with Grok 4.3 — verify text streams in real-time
- [ ] JSON-schema summarization (structured sections) returns valid JSON
- [ ] Web search with Grok still works (`web_search` tool path)
- [ ] Image analysis with Grok still works (Chat Completions fallback path)
- [ ] OpenAI providers still work (Chat Completions for non-search, Responses for search)

🤖 Generated with [Claude Code](https://claude.com/claude-code)